### PR TITLE
Add LinesLenPhysical property

### DIFF
--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -34,6 +34,7 @@ type
 const
   cLineEndStrings: array[TATLineEnds] of string = ('', #13#10, #10, #13);
   cLineEndNiceNames: array[TATLineEnds] of string = ('', 'win', 'un', 'mac');
+  cLineEndLength: array[TATLineEnds] of Byte = (0, 2, 1, 1);
 
 var
   OptMaxTabPositionToExpand: integer = 500; //no sense to expand too far tabs

--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -210,6 +210,7 @@ type
     function GetLineState(AIndex: integer): TATLineState;
     function GetLineLen(AIndex: integer): integer;
     function GetLineLenRaw(AIndex: integer): integer;
+    function GetLineLenPhysical(AIndex: integer): integer;
     function GetRedoCount: integer;
     function GetUndoCount: integer;
     function GetUndoLimit: integer;
@@ -256,6 +257,7 @@ type
     property LinesUTF8[Index: integer]: string read GetLineUTF8;
     property LinesLen[Index: integer]: integer read GetLineLen;
     property LinesLenRaw[Index: integer]: integer read GetLineLenRaw;
+    property LinesLenPhysical[Index: integer]: integer read GetLineLenPhysical;
     property LinesEnds[Index: integer]: TATLineEnds read GetLineEnd write SetLineEnd;
     property LinesHidden[IndexLine, IndexClient: integer]: boolean read GetLineHidden write SetLineHidden;
     property LinesFoldFrom[IndexLine, IndexClient: integer]: integer read GetLineFoldFrom write SetLineFoldFrom;
@@ -527,6 +529,15 @@ var
 begin
   ItemPtr:= FList.GetItem(AIndex);
   Result:= Length(ItemPtr^.Str);
+end;
+
+function TATStrings.GetLineLenPhysical(AIndex: integer): integer;
+var
+  ItemPtr: PATStringItem;
+begin
+  //Assert(IsIndexValid(AIndex));
+  ItemPtr:= FList.GetItem(AIndex);
+  Result:= Length(ItemPtr^.Str) + cLineEndLength[TATLineEnds(ItemPtr^.Ex.Ends)];
 end;
 
 function TATStrings.GetLineSep(AIndex: integer): TATLineSeparator;


### PR DESCRIPTION
Helps to translate accurately to and from a TATCaretItem to a Byte position.

I propose this mostly for me but it can be useful if for people having to match the tokens of a lexer or communicate with a daemon, etc