### PR TITLE
fix constant for user command not compat with 16 bit switches

### DIFF
--- a/atsynedit/atsynedit_commands.pas
+++ b/atsynedit/atsynedit_commands.pas
@@ -208,7 +208,7 @@ const
 
   // custom commands id must start here not to conflict
   // with built-in commands in the DoCommand overridden method.
-  cCommand_FirstUser = 100000;
+  cCommand_FirstUser = 30000;
 
 implementation
 


### PR DESCRIPTION
command identifier should not be over  1<<16 otherwise case of doesn't work.