### PR TITLE
Fix for IBUS IM

### DIFF
--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -7642,6 +7642,9 @@ begin
       len:=Length(buffer);
       bOverwrite:=ModeOverwrite and (Length(FIMSelText)=0);
       bSelect:=len>0;
+	  // fix for IBUS IM
+	  if (len=0) and (Message.WParam and GTK_IM_FLAG_REPLACE<>0) then
+	    TextInsertAtCarets('',False, bOverwrite, False);
       // commit
       if Message.WParam and GTK_IM_FLAG_COMMIT<>0 then
       begin

--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -7623,9 +7623,6 @@ var
 begin
   if (not ModeReadOnly) then
   begin
-    if (Message.WParam and GTK_IM_FLAG_START<>0) then
-      FIMSelText:=TextSelected;
-    // to do : candidate position
     // set candidate position
     if (Message.WParam and (GTK_IM_FLAG_START or GTK_IM_FLAG_PREEDIT))<>0 then
     begin
@@ -7638,6 +7635,8 @@ begin
     // valid string at composition & commit
     if Message.WParam and (GTK_IM_FLAG_COMMIT or GTK_IM_FLAG_PREEDIT)<>0 then
     begin
+	  if Message.WParam and GTK_IM_FLAG_REPLACE=0 then
+        FIMSelText:=TextSelected;
       // insert preedit or commit string
       buffer:=UTF8Decode(pchar(Message.LParam));
       len:=Length(buffer);
@@ -7652,6 +7651,7 @@ begin
         TextInsertAtCarets(buffer, False, False, bSelect);
     end;
     // end composition
+    // To Do : skip insert saved selection after commit with ibus.
     if (Message.WParam and GTK_IM_FLAG_END<>0) and (FIMSelText<>'') then
       TextInsertAtCarets(FIMSelText, False, False, False);
   end;


### PR DESCRIPTION
It is partial fix for IBUS IM.
It requires new patch at [fpc/lazarus bug tracker #38730](https://bugs.freepascal.org/view.php?id=38730)

It make possible working on IBUS IM. But there is one limitation.
Pre-Selected-Block manipulation cannot works properly. It's only IBUS IM limitation. 
fcitx IM works good with it.

