### PR TITLE
Fix blocked text multicarets insertion.

### DIFF
--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -7648,8 +7648,8 @@ begin
       bOverwrite:=ModeOverwrite and (Length(FIMSelText)=0);
       bSelect:=len>0;
 	  // fix for IBUS IM.
-	  //if (len=0) and (Message.WParam and GTK_IM_FLAG_REPLACE<>0) then
-	  //  TextInsertAtCarets('',False, bOverwrite, False);
+	  if (len=0) and (Message.WParam and GTK_IM_FLAG_REPLACE<>0) then
+	    TextInsertAtCarets('',False, bOverwrite, False);
       // commit
       if Message.WParam and GTK_IM_FLAG_COMMIT<>0 then
       begin

--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -7634,7 +7634,7 @@ var
   bOverwrite, bSelect: Boolean;
   Caret: TATCaretItem;
 begin
-  exit;
+  //exit;-
   //exiting, currently it breaks CudaText issue #3442
 
   if (not ModeReadOnly) then
@@ -7658,16 +7658,19 @@ begin
       len:=Length(buffer);
       bOverwrite:=ModeOverwrite and (Length(FIMSelText)=0);
       bSelect:=len>0;
-	  // fix for IBUS IM.
-	  if (len=0) and (Message.WParam and GTK_IM_FLAG_REPLACE<>0) then
-	    TextInsertAtCarets('',False, bOverwrite, False);
       // commit
-      if Message.WParam and GTK_IM_FLAG_COMMIT<>0 then
+      if len>0 then
       begin
-        TextInsertAtCarets(buffer, False, bOverwrite, False);
-        FIMSelText:='';
+        if Message.WParam and GTK_IM_FLAG_COMMIT<>0 then
+        begin
+          TextInsertAtCarets(buffer, False, bOverwrite, False);
+          FIMSelText:='';
+        end else
+          TextInsertAtCarets(buffer, False, False, bSelect);
       end else
-        TextInsertAtCarets(buffer, False, False, bSelect);
+        // fix for IBUS IM.
+        if Message.WParam and GTK_IM_FLAG_REPLACE<>0 then
+          TextInsertAtCarets('',False, bOverwrite, False);
     end;
     // end composition
     // To Do : skip insert saved selection after commit with ibus.

--- a/atsynedit/atsynedit_carets.pas
+++ b/atsynedit/atsynedit_carets.pas
@@ -621,7 +621,7 @@ end;
 procedure TATCarets.Sort(AJoinAdjacentCarets: boolean=true);
 begin
   FList.Sort(@_ListCaretsCompare);
-  DeleteDups(AJoinAdjacentCarets);
+  // DeleteDups(AJoinAdjacentCarets); // fix blocked text multicarets insertion.
 end;
 
 procedure TATCarets.DeleteDups(AJoinAdjacentCarets: boolean);


### PR DESCRIPTION
Fix Blocked text multicarets text insertion by preventing removing duplicated caret position after multicarets block deletion.

```
bb bb b b
12 34 5 6
^^ ^^ ^ ^
block deleted and sort carets, duplicated caret deleted ->
1 3 5 6
^ ^ ^ ^
```

