### PR TITLE
Hide composition form when editor lost focus on GTK.

### DIFF
--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -1801,6 +1801,7 @@ type
     procedure WMHScroll(var Msg: TLMHScroll); message LM_HSCROLL;
     procedure WMVScroll(var Msg: TLMVScroll); message LM_VSCROLL;
     procedure CMWantSpecialKey(var Message: TCMWantSpecialKey); message CM_WANTSPECIALKEY;
+    procedure WMKillFocus(var Message: TLMKillFocus); message LM_KILLFOCUS;
 
     {$ifdef windows}
     procedure WMIME_Request(var Msg: TMessage); message WM_IME_REQUEST;
@@ -9257,6 +9258,13 @@ begin
     else
       inherited;
   end;
+end;
+
+procedure TATSynEdit.WMKillFocus(var Message: TLMKillFocus);
+begin
+  inherited;
+  if Assigned(FAdapterIME) then
+    FAdapterIME.ImeKillFocus(Self);
 end;
 
 {$ifdef LCLGTK2}

--- a/atsynedit/atsynedit_adapter_gtk2ime.pas
+++ b/atsynedit/atsynedit_adapter_gtk2ime.pas
@@ -23,6 +23,7 @@ type
     procedure Stop(Sender: TObject; Success: boolean); override;
     procedure ImeEnter(Sender: TObject); override;
     procedure ImeExit(Sender: TObject); override;
+    procedure ImeKillFocus(Sender: TObject); override;
     procedure GTK2IMComposition(Sender: TObject; var Message: TLMessage); override;
   end;
 
@@ -131,6 +132,13 @@ end;
 
 procedure TATAdapterGTK2IME.ImeExit(Sender: TObject);
 begin
+  HideCompForm;
+end;
+
+procedure TATAdapterGTK2IME.ImeKillFocus(Sender: TObject);
+begin
+  inherited ImeKillFocus(Sender);
+  ResetDefaultIMContext;
   HideCompForm;
 end;
 

--- a/atsynedit/atsynedit_adapters.pas
+++ b/atsynedit/atsynedit_adapters.pas
@@ -114,6 +114,7 @@ type
     procedure ImeEndComposition(Sender: TObject; var Msg: TMessage); virtual;
     procedure ImeEnter(Sender: TObject); virtual;
     procedure ImeExit(Sender: TObject); virtual;
+    procedure ImeKillFocus(Sender: TObject); virtual;
     {$ifdef LCLGTK2}
     procedure GTK2IMComposition(Sender: TObject; var Message: TLMessage); virtual;
     {$endif}
@@ -160,6 +161,11 @@ begin
 end;
 
 procedure TATAdapterIME.ImeExit(Sender: TObject);
+begin
+  //
+end;
+
+procedure TATAdapterIME.ImeKillFocus(Sender: TObject);
 begin
   //
 end;


### PR DESCRIPTION
Fix bug :  
When editor lost focus, it still show input method composition form on GTK.  

