### PR TITLE
fix CR removed from last line

### DIFF
--- a/atsynedit/atstrings_load.inc
+++ b/atsynedit/atstrings_load.inc
@@ -503,11 +503,15 @@ var
           end;
         TATCharEnding.Ending13:
           begin
-            if AFoundPos+CharSize<BufSize then
-              if _GetBufferEnding(Buf, AFoundPos+CharSize, FEncoding)=TATCharEnding.Ending10 then
-                AEnding:= TATLineEnds.Windows
-              else
-                AEnding:= TATLineEnds.Mac;
+            //if CR is the last char of buffer, it cannot be part of CRLF pair,
+            //so it's a Mac-style line ending (fixes loss of trailing CR on load/save)
+            if AFoundPos+CharSize>=BufSize then
+              AEnding:= TATLineEnds.Mac
+            else
+            if _GetBufferEnding(Buf, AFoundPos+CharSize, FEncoding)=TATCharEnding.Ending10 then
+              AEnding:= TATLineEnds.Windows
+            else
+              AEnding:= TATLineEnds.Mac;
             exit
           end;
       end;


### PR DESCRIPTION
when a file ends with CR, that cr is not rendered,i see it like if the last line have no end of line, and if i save that file the cr is lost

AI fixed it and it works fine now

AI said:

## Where the bug is: **ATSynEdit**, not CudaText

`atsynedit/atstrings_load.inc` → `_FindNextEol` (nested inside `TATStrings.DoLoadFromStream`, the file loader). CudaText just calls `LoadFromFile` and consumes the result.

```pascal
TATCharEnding.Ending13:
  begin
    if AFoundPos+CharSize<BufSize then        // can we peek the NEXT char?
      if _GetBufferEnding(Buf, AFoundPos+CharSize, FEncoding)=TATCharEnding.Ending10 then
        AEnding:= TATLineEnds.Windows
      else
        AEnding:= TATLineEnds.Mac;
    exit                                       // <-- no peek possible: AEnding stays None
  end;
```

When CR is the **last byte of the file**, the peek is impossible → the CR is never stored as a line ending → both your symptoms from one root cause:
- **not rendered**: the EOL-mark painter just reads `St.LinesEnds[line]` (atsynedit.pas:4588) → None → no mark;
- **lost on save**: `SaveToStream` writes only *stored* endings (atstrings_save.inc:101) → nothing written.

Why only CR suffers: LF needs no peek, and in CRLF the #13 is never the final byte (the #10 is). Mid-file CRs are fine — only the file's **last** CR is dropped. Worse than you thought: a file containing just `\r` (1 byte) loads as an **empty document** and saves as 0 bytes.

**Git archaeology**: this is a 9-year-old regression from commit `b7141ce4` (2017-08-01, "rework ATStrings.LoadFromStream"). The *pre-2017* code peeked if possible, then classified `13+10=Win / 13=Mac / 10=Unix` — a peek-less #13 correctly became Mac. The rework inverted the logic to "only classify if peek possible" and lost the trailing-CR case. Not a speed trade-off — an accidental logic inversion in a refactor.

## The fix

If CR is the last char, there's no room for a following #10, so it **cannot** be half of a CRLF pair — it must be a lone Mac EOL:

```pascal
if AFoundPos+CharSize>=BufSize then
  AEnding:= TATLineEnds.Mac
else
if _GetBufferEnding(Buf, AFoundPos+CharSize, FEncoding)=TATCharEnding.Ending10 then
  AEnding:= TATLineEnds.Windows
else
  AEnding:= TATLineEnds.Mac;
```

After the fix, `abc\r` produces exactly the state `abc\n`/`abc\r\n` already produce — last real line with ending + fake line — which every consumer already handles. Bonus: multi-line **paste** funnels through this same loader (`TextInsert` → `Block.LoadFromString`), so pasting CR-terminated text at doc end is fixed too.
