### PR TITLE
improve wrap performance

### DIFF
--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -3347,6 +3347,7 @@ var
   NCommandCode, NLineIndexFailed: integer;
   NTickCount: QWord;
   PrevUndoOrRedo: TATEditorRunningUndoOrRedo;
+  i, NCountOther: integer;
 begin
   if not Assigned(FUndoList) then Exit;
   if not Assigned(FRedoList) then Exit;
@@ -3390,6 +3391,14 @@ begin
   }
   FLastUndoY:= -1;
 
+  //init values, which are filled by UndoSingle() below;
+  //needed if repeat-loop exits before any UndoSingle() call,
+  //because code in 'finally' section reads them
+  bSoftMarked:= false;
+  bHardMarked:= false;
+  bHardMarkedNext:= false;
+  bMarkedUnmodified:= false;
+
  try
   repeat
     //better to have this, e.g. for Undo after Ctrl+A, Del
@@ -3398,6 +3407,11 @@ begin
 
     if List.Count=0 then Break;
     if List.IsEmpty then Break;
+
+    //count of items in ListOther, before this undo/redo step;
+    //new mirror-items (added to ListOther by UndoSingle) occupy indexes
+    //NCountOther..ListOther.Count-1
+    NCountOther:= ListOther.Count;
 
     if not UndoSingle(
              List,
@@ -3424,12 +3438,16 @@ begin
       FModified:= false;
 
     //apply Hardmark to ListOther
+    //CudaText issue #6446: one UndoSingle() call can add to ListOther not one
+    //item, but several items, e.g. undoing of Delete-item with CurIndex>=Count
+    //calls LineAddRaw() + ActionFixEolBeforeLast(), which add 'Add'-item and
+    //'ChangeEol'-item. Old code (marked only ListOther.Last) leaved first such
+    //items without hardmark, so next Redo (with AGrouped=false) breaked the
+    //chain of hardmarks and stopped in the middle of the undo-group, giving
+    //wrong text. So we mark here ALL items added by this undo/redo step.
     if bHardMarked then
-      if ListOther.Count>0 then
-      begin
-        ListOther.Last.ItemHardMark:= bHardMarked;
-        //ListOther.Last.ItemSoftMark:= ?? //for redo needed Softmark too but don't know how
-      end;
+      for i:= NCountOther to ListOther.Count-1 do
+        ListOther.Items[i].ItemHardMark:= bHardMarked;
 
     if bHardMarked and bHardMarkedNext and not bSoftMarked then
       Continue;
@@ -3453,7 +3471,13 @@ begin
   FEnabledCaretsInUndo:= true;
 
   //apply SoftMark to ListOther
-  if bSoftMarked and AGrouped then
+  //CudaText issue #6446: condition 'and AGrouped' was wrong here, it leaved
+  //mirror-groups without softmark terminators when option undo_grouped=false,
+  //so Redo worked wrong (stopped inside a group / over-consumed groups).
+  //ListOther.SoftMark affects only the NEXT item, added to ListOther, i.e.
+  //the first mirror-item of the next undone/redone group; that item is
+  //processed last, and it terminates the group - in both grouped/ungrouped modes.
+  if bSoftMarked then
     ListOther.SoftMark:= true;
 
   //to fix this:

--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -254,6 +254,12 @@ type
     procedure AddUndoItem(AAction: TATEditAction; AIndex: SizeInt;
       const AText: atString; AEnd: TATLineEnds; ALineState: TATLineState;
       ACommandCode: integer);
+    procedure AddUndoItemEx(AAction: TATEditAction; AIndex: SizeInt;
+      const AText: atString; AEnd: TATLineEnds; ALineState: TATLineState;
+      ACommandCode: integer;
+      const ACarets, ACarets2: TATPointPairArray;
+      const AMarkers, AMarkers2: TATMarkerMarkerArray;
+      const AAttribs: TATMarkerAttribArray);
     function DebugText: string;
     function IsFilled: boolean;
     procedure DoFinalizeSaving;
@@ -2530,10 +2536,12 @@ Two run kinds are handled (detection is done in UndoCountRun):
 
 It makes the same work as UndoSingle() called for each item separately:
 - same redo-items are created (one per deleted line, with same texts/ends/states);
-- same events (OnUndoBefore/OnUndoAfter, DoEventLog, DoEventChange) in same cases;
-- same carets/markers/attribs are restored per item;
+- same OnUndoBefore/OnUndoAfter events in same cases;
+- same final carets/markers/attribs are restored (values of the last item);
 - same mark-handling of 'other' list items;
 - same handling of too long lines (partial undo, then exit(False)).
+Line-change events (OnChangeLog, OnChangeEx) are coalesced: one event for
+the whole range, with AItemCount>1, like TextInsert() already does.
 
 Only the physical deletion is changed: ONE FList.DeleteRange() call instead of
 ACount of FList.Delete() calls, each of which moved all tail items (O(n^2) total).
@@ -2544,12 +2552,16 @@ var
   CurCaretsArray, CurCaretsArray2: TATPointPairArray;
   CurMarkersArray, CurMarkersArray2: TATMarkerMarkerArray;
   CurAttribsArray: TATMarkerAttribArray;
+  LastCaretsArray, LastCaretsArray2: TATPointPairArray;
+  LastMarkersArray, LastMarkersArray2: TATMarkerMarkerArray;
+  LastAttribsArray: TATMarkerAttribArray;
+  bLastCarets, bLastCarets2: boolean;
   OtherList: TATUndoList;
   ItemData: PATStringItem;
   NEventX, NEventY: SizeInt;
   bWithoutPause, bEnableEventAfter, bConsecutive: boolean;
   bCurHardMarked, bCurHardMarkedNext, bCurUnmodifiedNext: boolean;
-  j, N, NRunCount, NItemIndex, NLineIndex: SizeInt;
+  j, N, NRunCount, NItemIndex, NLineIndex, NRangeStart: SizeInt;
 begin
   Result:= true;
   ASoftMarked:= true;
@@ -2559,6 +2571,13 @@ begin
   ACommandCode:= 0;
   ATickCount:= 0;
   ALineIndexFailed:= -1;
+  bLastCarets:= false;
+  bLastCarets2:= false;
+  LastCaretsArray:= nil;
+  LastCaretsArray2:= nil;
+  LastMarkersArray:= nil;
+  LastMarkersArray2:= nil;
+  LastAttribsArray:= nil;
 
   N:= ACurList.Count;
   if ACurList=FUndoList then
@@ -2653,17 +2672,22 @@ begin
       UpdateModified;
       AddUndoItem(TATEditAction.Delete, NItemIndex,
         ItemData^.Line, ItemData^.LineEnds, ItemData^.LineState, FCommandCode);
-      DoEventLog(NItemIndex);
-      DoEventChange(TATLineChangeKind.Deleted, NItemIndex, 1);
 
+      //remember the last values of carets/markers/attribs: they are applied
+      //once after the loop (coalesced events), see comment below
       if Length(CurCaretsArray)>0 then
-        SetCaretsArray(CurCaretsArray);
+      begin
+        LastCaretsArray:= CurCaretsArray;
+        bLastCarets:= true;
+      end;
       if Length(CurCaretsArray2)>0 then
-        SetCaretsArray2(CurCaretsArray2);
-
-      SetMarkersArray(CurMarkersArray);
-      SetMarkersArray2(CurMarkersArray2);
-      SetAttribsArray(CurAttribsArray);
+      begin
+        LastCaretsArray2:= CurCaretsArray2;
+        bLastCarets2:= true;
+      end;
+      LastMarkersArray:= CurMarkersArray;
+      LastMarkersArray2:= CurMarkersArray2;
+      LastAttribsArray:= CurAttribsArray;
     finally
       UndoSingle_End(ACurList, true, bEnableEventAfter, NEventX, NEventY);
     end;
@@ -2691,11 +2715,31 @@ begin
   if NRunCount>0 then
   begin
     if bConsecutive then
-      FList.DeleteRange(ALineIndex+ACount-NRunCount, ALineIndex+ACount-1)
+    begin
+      FList.DeleteRange(ALineIndex+ACount-NRunCount, ALineIndex+ACount-1);
+      NRangeStart:= ALineIndex+ACount-NRunCount;
+    end
     else
+    begin
       FList.DeleteRange(ALineIndex, ALineIndex+NRunCount-1);
+      NRangeStart:= ALineIndex;
+    end;
     //LineDelete(AForceLast=true) was made per item, same final fixup here
     ActionAddFakeLineIfNeeded;
+
+    //coalesced events for the whole deleted range (same as UndoRunDeletes(),
+    //see comment there): old code fired them per line, N event-roundtrips
+    //into the editor made undo of big blocks seconds-slow
+    DoEventLog(NRangeStart);
+    DoEventChange(TATLineChangeKind.Deleted, NRangeStart, NRunCount);
+
+    if bLastCarets then
+      SetCaretsArray(LastCaretsArray);
+    if bLastCarets2 then
+      SetCaretsArray2(LastCaretsArray2);
+    SetMarkersArray(LastMarkersArray);
+    SetMarkersArray2(LastMarkersArray2);
+    SetAttribsArray(LastAttribsArray);
   end;
 
   if Result then Exit;
@@ -2755,7 +2799,14 @@ UndoCountRun):
   LineBlockDelete() (e.g. DEL with many selected lines, issue #368).
 Per-item processing (LineInsertRaw per item) was O(n^2).
 
-It makes the same work as UndoSingle() called for each item separately.
+It makes the same work as UndoSingle() called for each item separately:
+- same redo-items are created (one per deleted line, with same texts/ends/states);
+- same OnUndoBefore/OnUndoAfter events in same cases;
+- same final carets/markers/attribs are restored (values of the last item);
+- same mark-handling of 'other' list items;
+Line-change events (OnChangeLog, OnChangeEx) are coalesced: one event for
+the whole range, with AItemCount>1, like TextInsert() already does.
+
 Only the physical insert is changed: ONE FList.InsertRange() call opens the
 gap for all lines, then items are written to gap slots.
 Caller checks: ALineIndex>=0, ALineIndex<Count, items form a run.
@@ -2765,6 +2816,10 @@ var
   CurCaretsArray, CurCaretsArray2: TATPointPairArray;
   CurMarkersArray, CurMarkersArray2: TATMarkerMarkerArray;
   CurAttribsArray: TATMarkerAttribArray;
+  LastCaretsArray, LastCaretsArray2: TATPointPairArray;
+  LastMarkersArray, LastMarkersArray2: TATMarkerMarkerArray;
+  LastAttribsArray: TATMarkerAttribArray;
+  bLastCarets, bLastCarets2: boolean;
   OtherList: TATUndoList;
   Item: TATStringItem;
   PItem: PATStringItem;
@@ -2781,6 +2836,13 @@ begin
   ACommandCode:= 0;
   ATickCount:= 0;
   ALineIndexFailed:= -1;
+  bLastCarets:= false;
+  bLastCarets2:= false;
+  LastCaretsArray:= nil;
+  LastCaretsArray2:= nil;
+  LastMarkersArray:= nil;
+  LastMarkersArray2:= nil;
+  LastAttribsArray:= nil;
 
   N:= ACurList.Count;
   if ACurList=FUndoList then
@@ -2867,8 +2929,6 @@ begin
       UpdateModified;
       AddUndoItem(TATEditAction.Insert, NItemIndex, '',
         TATLineEnds.None, TATLineState.None, FCommandCode);
-      DoEventLog(NItemIndex);
-      DoEventChange(TATLineChangeKind.Added, NItemIndex, 1);
 
       //physical line write: same-index runs write the line here, walking
       //PItem down from the end of block; consecutive runs got all lines
@@ -2891,14 +2951,21 @@ begin
       //line, just inserted by item j, is at slot NLineSlot
       LinesState[NLineSlot]:= CurItem.ItemLineState;
 
+      //remember the last values of carets/markers/attribs: they are applied
+      //once after the loop (coalesced events), see comment below the loop
       if Length(CurCaretsArray)>0 then
-        SetCaretsArray(CurCaretsArray);
+      begin
+        LastCaretsArray:= CurCaretsArray;
+        bLastCarets:= true;
+      end;
       if Length(CurCaretsArray2)>0 then
-        SetCaretsArray2(CurCaretsArray2);
-
-      SetMarkersArray(CurMarkersArray);
-      SetMarkersArray2(CurMarkersArray2);
-      SetAttribsArray(CurAttribsArray);
+      begin
+        LastCaretsArray2:= CurCaretsArray2;
+        bLastCarets2:= true;
+      end;
+      LastMarkersArray:= CurMarkersArray;
+      LastMarkersArray2:= CurMarkersArray2;
+      LastAttribsArray:= CurAttribsArray;
     finally
       UndoSingle_End(ACurList, true, bEnableEventAfter, NEventX, NEventY);
     end;
@@ -2916,6 +2983,35 @@ begin
       if OtherList.Count>0 then
         OtherList.Last.ItemHardMark:= true;
   end;
+
+  {
+  2026.09: coalesced events (2nd performance fix of issue #368).
+  Old code (UndoSingle per item) fired DoEventLog/DoEventChange/SetCaretsArray/
+  SetMarkersArray/SetAttribsArray once PER LINE of the run: for a run of N=100K
+  lines, the editor received N event-roundtrips (each one runs TATSynEdit
+  handlers: Carets.AsArray + DoCaretsFixIncorrectPos for SetCaretsArray, then
+  CudaText-level handlers of OnChangeEx/OnChangeLog), which made undo of big
+  blocks 10+ seconds slow even with the O(N) list work, e.g. CudaText test
+  (300K lines file, DEL first 200K lines, then Undo): 19-59 seconds spent in
+  per-item event handlers.
+  Bulk operations of the editor already use coalesced events with AItemCount>1:
+  TextInsert() ends with single DoEventLog(AY) + DoEventChange(Added, AY, Count)
+  for the whole inserted block; TATGaps/TATBookmarks/TATSynEdit.Fold handle
+  AItemCount>1 natively. Same is done here: one event for the whole run.
+  Carets/markers/attribs: only the values of the LAST processed item are applied
+  (for all-same-values runs and for mirror-runs, this gives the same final
+  editor state as N per-item applications: the last application wins).
+  }
+  DoEventLog(ALineIndex);
+  DoEventChange(TATLineChangeKind.Added, ALineIndex, ACount);
+
+  if bLastCarets then
+    SetCaretsArray(LastCaretsArray);
+  if bLastCarets2 then
+    SetCaretsArray2(LastCaretsArray2);
+  SetMarkersArray(LastMarkersArray);
+  SetMarkersArray2(LastMarkersArray2);
+  SetAttribsArray(LastAttribsArray);
 end;
 
 
@@ -3086,6 +3182,71 @@ begin
     GetMarkersArray,
     GetMarkersArray2,
     GetAttribsArray,
+    ACommandCode,
+    FRunningUndoOrRedo
+    );
+end;
+
+procedure TATStrings.AddUndoItemEx(AAction: TATEditAction; AIndex: SizeInt;
+  const AText: atString; AEnd: TATLineEnds; ALineState: TATLineState;
+  ACommandCode: integer;
+  const ACarets, ACarets2: TATPointPairArray;
+  const AMarkers, AMarkers2: TATMarkerMarkerArray;
+  const AAttribs: TATMarkerAttribArray);
+{
+2026.09: performance fix, for LineBlockDelete(): same as AddUndoItem(), but carets/
+markers/attribs are passed by caller (they are captured once for the whole deleted
+block, not per line). It makes the same undo-items: AddUndoItem() captured the
+SAME arrays for every line of one block-delete (nothing changes during its loop:
+it doesn't fire per-line events, carets/markers don't move).
+}
+var
+  CurList: TATUndoList;
+begin
+  if FUndoList=nil then exit;
+  if FRedoList=nil then exit;
+  if FUndoLimit=0 then exit;
+
+  if not FUndoList.Locked then
+    CurList:= FUndoList
+  else
+  if not FRedoList.Locked then
+    CurList:= FRedoList
+  else
+    exit;
+
+  if Length(AText)>ATEditorOptions.MaxLineLenForUndo then
+  begin
+    if Assigned(FOnUndoTooLongLine) then
+      FOnUndoTooLongLine(Self, -1, -1);
+    CurList.Clear;
+    exit
+  end;
+
+  //handle CaretJump: (not used by LineBlockDelete, kept for symmetry)
+  if AAction=TATEditAction.CaretJump then
+  begin
+    if (CurList.Count>0) and (CurList.Last.ItemAction=AAction) then
+      CurList.DeleteLast;
+  end
+  else
+  begin
+    if not FUndoList.Locked and not FRedoList.Locked then
+      FRedoList.Clear;
+    AddUpdatesAction(AIndex, AAction);
+  end;
+
+  CurList.Add(
+    AAction,
+    AIndex,
+    AText,
+    AEnd,
+    ALineState,
+    ACarets,
+    ACarets2,
+    AMarkers,
+    AMarkers2,
+    AAttribs,
     ACommandCode,
     FRunningUndoOrRedo
     );

--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -62,6 +62,43 @@ type
     InsertColumn
   );
 
+type
+  {
+  2026.09: performance fix (word-wrap). Structural line changes, which were made
+  in TATStrings since the last TATSynEdit.UpdateWrapInfo() call, are recorded
+  here as a short list of simple ops. Wrap-info update can apply these ops
+  incrementally (shift line indexes, recalc wrap only for new lines), instead
+  of the full recalculation of WrapInfo for all editor lines (which is very
+  slow for big documents, e.g. CudaText test: 300K lines, DEL of 200K lines
+  with word-wrap enabled takes ~6 sec, UNDO takes ~60 sec).
+  Ops are recorded in TATStrings.DoEventChange() for events Added/Deleted.
+  Each op is expressed in line indexes of the document state BEFORE the op.
+  Ops list is cleared when editor applies it in UpdateWrapInfo(), or when
+  wrapping falls back to the full recalculation.
+  }
+  TATWrapStructOpKind = (
+    Inserted,
+    Deleted
+    );
+
+  TATWrapStructOp = record
+    Kind: TATWrapStructOpKind;
+    Line: SizeInt; //first line of the range, in coordinates before the op
+    Count: SizeInt; //number of inserted/deleted lines
+    Hashes: array of QWord; //for Kind=Deleted: hash of each deleted line's text
+    HashesAll: boolean; //True when Hashes[] covers all Count lines (enables wrap-cache reuse on undo)
+  end;
+
+  TATWrapStructOpArray = array of TATWrapStructOp;
+
+const
+  ATStrings_MaxWrapStructOps = 8;
+    //if more structural ops are made before UpdateWrapInfo() applies them,
+    //tracking is marked "complex" and full recalculation is used
+  ATStrings_MaxWrapStructHashes = 2*1024*1024;
+    //hard limit of stored deleted-lines hashes (16 MB of QWords); ops with
+    //more deleted lines get HashesAll=False (no wrap-cache reuse for them)
+
 const
   cEncodingSize: array[TATFileEncoding] of integer = (1, 1, 2, 2, 4, 4);
 
@@ -190,6 +227,8 @@ type
     FList: TATStringItemList;
     FIndexesOfEditedLines: TATIntegerList;
     FEnableCachedWrapinfoUpdate: boolean;
+    FWrapStructOps: TATWrapStructOpArray;
+    FWrapStructComplex: boolean;
     FGaps: TATGaps;
     FBookmarks: TATBookmarks;
     FBookmarks2: TATBookmarks;
@@ -335,6 +374,8 @@ type
       out ATickCount: QWord;
       out ALineIndexFailed: integer): boolean;
     procedure AddUpdatesAction(ALineIndex: integer; AAction: TATEditAction);
+    procedure WrapStructRecord(AKind: TATWrapStructOpKind; ALine, ACount: SizeInt);
+    procedure WrapStructShiftEditedIndexes(AKind: TATWrapStructOpKind; ALine, ACount: SizeInt);
     procedure UpdateModified;
     procedure LineInsertToSlot(AIndexForUndoItem, AIndexForLine: SizeInt; const AString: atString);
   public
@@ -396,6 +437,14 @@ type
     property LoadingFromStream: boolean read FLoadingFromStream write FLoadingFromStream;
     property IndexesOfEditedLines: TATIntegerList read FIndexesOfEditedLines; //list has line indexes of edited lines; UpdateWrapInfo maybe performs cached update
     property EnableCachedWrapinfoUpdate: boolean read FEnableCachedWrapinfoUpdate write FEnableCachedWrapinfoUpdate; //if False, UpdateWrapInfo cached update will be disabled for the next call
+
+    //2026.09: structural line changes since the last UpdateWrapInfo();
+    //used by TATSynEdit.UpdateWrapInfo() for the incremental WrapInfo update
+    property WrapStructOps: TATWrapStructOpArray read FWrapStructOps;
+    property WrapStructComplex: boolean read FWrapStructComplex;
+    procedure WrapStructClear; //forget all recorded ops (used after WrapInfo was fully recalculated, or document was cleared/replaced)
+    procedure WrapStructInvalidate; //mark tracking as complex: next UpdateWrapInfo() must fully recalculate (e.g. folding state was changed)
+    function GetLineHash(AIndex: SizeInt): QWord; //stable hash of line's raw buffer; used to identify restored-on-undo lines
     property Modified: boolean read FModified write SetModified;
     property ModifiedRecent: boolean read FModifiedRecent write FModifiedRecent;
     property ModifiedVersion: Int64 read FModifiedVersion;
@@ -1524,7 +1573,13 @@ end;
 procedure TATStrings.ActionDeleteFakeLine;
 begin
   if IsLastLineFake then
+  begin
     LineDelete(Count-1, false{AForceLast}, false, false);
+    //2026.09: LineDelete is silent here (AWithEvent=false), but wrap-struct
+    //tracking must know about this line deletion: record op directly
+    //(deleted line had index = current Count, in before-op coordinates)
+    WrapStructRecord(TATWrapStructOpKind.Deleted, Count, 1);
+  end;
 end;
 
 procedure TATStrings.ActionDeleteFakeLineAndFinalEol;
@@ -1543,6 +1598,9 @@ begin
   if Count=0 then
   begin
     LineAddRaw('', TATLineEnds.None, false{AWithEvent});
+    //2026.09: record silent line add for wrap-struct tracking
+    //(added line has index = current Count-1, in before-op coordinates)
+    WrapStructRecord(TATWrapStructOpKind.Inserted, Count-1, 1);
     Exit(true);
   end;
 
@@ -1552,6 +1610,8 @@ begin
   if LinesEnds[Count-1]<>TATLineEnds.None then
   begin
     LineAddRaw('', TATLineEnds.None, false{AWithEvent});
+    //2026.09: record silent line add for wrap-struct tracking
+    WrapStructRecord(TATWrapStructOpKind.Inserted, Count-1, 1);
     Exit(true);
   end;
 
@@ -1937,6 +1997,7 @@ begin
   FList.Clear;
   IndexesOfEditedLines.Clear;
   EnableCachedWrapinfoUpdate:= false;
+  WrapStructClear; //document is replaced: all recorded structural ops are not valid
 end;
 
 procedure TATStrings.ClearLineStates(ASaved: boolean; AFrom: SizeInt=-1; ATo: SizeInt=-1);
@@ -2641,7 +2702,9 @@ begin
     CurMarkersArray:= CurItem.ItemMarkers;
     CurMarkersArray2:= CurItem.ItemMarkers2;
     CurAttribsArray:= CurItem.ItemAttribs;
-    bWithoutPause:= IsCommandToUndoInOneStep(ACommandCode);
+    //2026.09: always disable pause-events for items of a bulk run:
+    //one undo step must not scroll/pause the editor in its middle
+    bWithoutPause:= true;
 
     UndoSingle_Begin(ACurList, CurItem.ItemAction, ACommandCode,
       ASoftMarked, AHardMarked, bWithoutPause, CurCaretsArray,
@@ -2716,22 +2779,29 @@ begin
   begin
     if bConsecutive then
     begin
-      FList.DeleteRange(ALineIndex+ACount-NRunCount, ALineIndex+ACount-1);
       NRangeStart:= ALineIndex+ACount-NRunCount;
     end
     else
     begin
-      FList.DeleteRange(ALineIndex, ALineIndex+NRunCount-1);
       NRangeStart:= ALineIndex;
     end;
-    //LineDelete(AForceLast=true) was made per item, same final fixup here
-    ActionAddFakeLineIfNeeded;
 
     //coalesced events for the whole deleted range (same as UndoRunDeletes(),
     //see comment there): old code fired them per line, N event-roundtrips
-    //into the editor made undo of big blocks seconds-slow
+    //into the editor made undo of big blocks seconds-slow.
+    //2026.09: events are fired BEFORE the physical deletion, like LineDelete()
+    //does; WrapStructRecord() needs the deleted lines to be still present
+    //(it hashes their texts, to reuse wrap-items on redo)
     DoEventLog(NRangeStart);
     DoEventChange(TATLineChangeKind.Deleted, NRangeStart, NRunCount);
+
+    if bConsecutive then
+      FList.DeleteRange(ALineIndex+ACount-NRunCount, ALineIndex+ACount-1)
+    else
+      FList.DeleteRange(ALineIndex, ALineIndex+NRunCount-1);
+
+    //LineDelete(AForceLast=true) was made per item, same final fixup here
+    ActionAddFakeLineIfNeeded;
 
     if bLastCarets then
       SetCaretsArray(LastCaretsArray);
@@ -2856,6 +2926,18 @@ begin
   //ATStrings_MinUndoRunCount)
   bForwardFill:= (ACount>=2) and (ACurList.Items[N-2].ItemIndex=ALineIndex+1);
 
+  //2026.09: coalesced events for the whole run (was at the end of function):
+  //- fired BEFORE the physical insertion, like LineInsert() does:
+  //  WrapStructRecord() must shift edited-line indexes before lines move,
+  //  and fake-line ops (recorded by the per-item loop below) are expressed
+  //  in coordinates, which already include this insertion;
+  //- pause-events (OnUndoBefore/OnUndoAfter) are disabled for all items of
+  //  the run (see bWithoutPause in the loop): a bulk run is one undo step,
+  //  it must not scroll/pause the editor in the middle of it (also, painting
+  //  inside the run needs WrapInfo for a not-yet-complete document state)
+  DoEventLog(ALineIndex);
+  DoEventChange(TATLineChangeKind.Added, ALineIndex, ACount);
+
   //open the gap for all lines at ALineIndex, in one operation;
   //gap slots are zeroed, same as single Insert() zeroes its slot
   FList.InsertRange(ALineIndex, ACount);
@@ -2911,7 +2993,9 @@ begin
     CurMarkersArray:= CurItem.ItemMarkers;
     CurMarkersArray2:= CurItem.ItemMarkers2;
     CurAttribsArray:= CurItem.ItemAttribs;
-    bWithoutPause:= IsCommandToUndoInOneStep(ACommandCode);
+    //2026.09: always disable pause-events for items of a bulk run:
+    //one undo step must not scroll/pause the editor in its middle
+    bWithoutPause:= true;
 
     UndoSingle_Begin(ACurList, CurItem.ItemAction, ACommandCode,
       ASoftMarked, AHardMarked, bWithoutPause, CurCaretsArray,
@@ -2997,13 +3081,13 @@ begin
   Bulk operations of the editor already use coalesced events with AItemCount>1:
   TextInsert() ends with single DoEventLog(AY) + DoEventChange(Added, AY, Count)
   for the whole inserted block; TATGaps/TATBookmarks/TATSynEdit.Fold handle
-  AItemCount>1 natively. Same is done here: one event for the whole run.
+  AItemCount>1 natively. Same is done here: one event for the whole run
+  (DoEventLog/DoEventChange are fired at the beginning of the function, before
+  the physical insertion - like LineInsert() does).
   Carets/markers/attribs: only the values of the LAST processed item are applied
   (for all-same-values runs and for mirror-runs, this gives the same final
   editor state as N per-item applications: the last application wins).
   }
-  DoEventLog(ALineIndex);
-  DoEventChange(TATLineChangeKind.Added, ALineIndex, ACount);
 
   if bLastCarets then
     SetCaretsArray(LastCaretsArray);
@@ -3443,9 +3527,19 @@ begin
 end;
 
 procedure TATStrings.ActionDeleteDupFakeLines;
+var
+  NDeleted: SizeInt;
 begin
+  NDeleted:= 0;
   while IsLastFakeLineUnneeded do
+  begin
     LineDelete(Count-1, false, false, false);
+    Inc(NDeleted);
+  end;
+  //2026.09: LineDelete is silent here (AWithEvent=false), record ops directly:
+  //deleted lines had indexes [Count .. Count+NDeleted-1] in before-op coordinates
+  if NDeleted>0 then
+    WrapStructRecord(TATWrapStructOpKind.Deleted, Count, NDeleted);
 end;
 
 function TATStrings.ActionDeleteAllBlanks: boolean;
@@ -3668,6 +3762,220 @@ begin
     IndexesOfEditedLines.Add(ALineIndex);
 end;
 
+
+procedure TATStrings.WrapStructRecord(AKind: TATWrapStructOpKind; ALine, ACount: SizeInt);
+{
+Records one structural line op (made by this event) in the ops list, merging it
+with the last op when possible. Each op has line indexes of the document state
+BEFORE that op, so editor applies ops to WrapInfo in the same order.
+Merge rules (conservative; anything not mergeable marks the tracking complex,
+which makes the next UpdateWrapInfo() use full recalculation - like it always
+worked before 2026.09):
+- "Inserted at Q, M" merges with pending "Inserted at P, K" when new lines
+  continue the same block: Q in [P-1 .. P+K].
+- "Deleted at Q, M" merges with pending "Deleted at P, K" when removed ranges
+  are adjacent in the pending op's "before" coordinates:
+  * Q+M-1 = P-1: adjacent above (e.g. LineBlockDelete's loop from ALine2
+    downto ALine1, or undo of a block-insert run, pops items with
+    decreasing indexes);
+  * Q = P: adjacent below, in current coordinates (e.g. per-item undo of a
+    same-index Insert run, LineDelete at same index);
+  * Q+M-1 < P-1 or Q > P: not adjacent, full recalculation.
+- "Deleted" followed by "Inserted" (e.g. TextReplaceLines) is not merged:
+  full recalculation is used.
+IndexesOfEditedLines entries are shifted here, to keep them valid in the
+coordinates after all ops (entries can be recorded before a structural op).
+Hashes of deleted lines are merged in line order, so undo of the whole block
+can reuse the wrap-items cache.
+}
+var
+  Last: ^TATWrapStructOp;
+  CurHashes: array of QWord;
+  bCurHashesAll: boolean;
+  i: SizeInt;
+  bMerged, bMergeAbove: boolean;
+begin
+  if FWrapStructComplex then Exit;
+
+  //line indexes of edited lines (recorded earlier) must be shifted now
+  WrapStructShiftEditedIndexes(AKind, ALine, ACount);
+
+  if ACount<=0 then Exit;
+
+  //hash texts of deleted lines, to let editor reuse their wrap-items on undo;
+  //lines must be still present: all "Deleted" events are fired before
+  //the physical deletion (LineDelete/LineBlockDelete/UndoRunInserts)
+  bCurHashesAll:= false;
+  if AKind=TATWrapStructOpKind.Deleted then
+    if ACount<=ATStrings_MaxWrapStructHashes then
+    begin
+      SetLength(CurHashes, ACount);
+      bCurHashesAll:= true;
+      for i:= 0 to ACount-1 do
+        if IsIndexValid(ALine+i) then
+          CurHashes[i]:= GetLineHash(ALine+i)
+        else
+        begin
+          SetLength(CurHashes, 0);
+          bCurHashesAll:= false;
+          Break
+        end;
+    end;
+
+  if Length(FWrapStructOps)>0 then
+  begin
+    Last:= @FWrapStructOps[High(FWrapStructOps)];
+    bMerged:= false;
+
+    case AKind of
+      TATWrapStructOpKind.Inserted:
+        if Last^.Kind=TATWrapStructOpKind.Inserted then
+          if (ALine>=Last^.Line-1) and (ALine<=Last^.Line+Last^.Count) then
+          begin
+            if ALine<Last^.Line then
+              Dec(Last^.Line, ACount); //inserted block starts earlier
+            Inc(Last^.Count, ACount);
+            bMerged:= true;
+          end;
+
+      TATWrapStructOpKind.Deleted:
+        if Last^.Kind=TATWrapStructOpKind.Deleted then
+          if (ALine+ACount-1=Last^.Line-1) or (ALine=Last^.Line) then
+          begin
+            bMergeAbove:= ALine+ACount-1=Last^.Line-1;
+            if bMergeAbove then
+              Dec(Last^.Line, ACount); //removed block starts earlier
+            Inc(Last^.Count, ACount);
+            //merge hashes in line order
+            if Last^.HashesAll and bCurHashesAll then
+            begin
+              if bMergeAbove then
+              begin
+                SetLength(Last^.Hashes, Length(Last^.Hashes)+ACount);
+                for i:= High(Last^.Hashes) downto ACount do
+                  Last^.Hashes[i]:= Last^.Hashes[i-ACount];
+                for i:= 0 to ACount-1 do
+                  Last^.Hashes[i]:= CurHashes[i];
+              end
+              else
+              begin
+                SetLength(Last^.Hashes, Length(Last^.Hashes)+ACount);
+                for i:= 0 to ACount-1 do
+                  Last^.Hashes[Length(Last^.Hashes)-ACount+i]:= CurHashes[i];
+              end;
+            end
+            else
+            begin
+              SetLength(Last^.Hashes, 0);
+              Last^.HashesAll:= false;
+            end;
+            bMerged:= true;
+          end;
+    end;
+
+    if bMerged then
+    begin
+      if Length(Last^.Hashes)>ATStrings_MaxWrapStructHashes then
+      begin
+        SetLength(Last^.Hashes, 0);
+        Last^.HashesAll:= false;
+      end;
+      Exit
+    end;
+  end;
+
+  if Length(FWrapStructOps)>=ATStrings_MaxWrapStructOps then
+  begin
+    WrapStructInvalidate;
+    Exit
+  end;
+
+  SetLength(FWrapStructOps, Length(FWrapStructOps)+1);
+  Last:= @FWrapStructOps[High(FWrapStructOps)];
+  FillChar(Last^, SizeOf(Last^), 0);
+  Last^.Kind:= AKind;
+  Last^.Line:= ALine;
+  Last^.Count:= ACount;
+  if bCurHashesAll then
+  begin
+    Last^.Hashes:= CurHashes;
+    Last^.HashesAll:= true;
+  end;
+end;
+
+procedure TATStrings.WrapStructShiftEditedIndexes(AKind: TATWrapStructOpKind; ALine, ACount: SizeInt);
+var
+  List: TATIntegerList;
+  i, N, NWritten: integer;
+begin
+  List:= IndexesOfEditedLines;
+  if not Assigned(List) then Exit;
+  if List.Count=0 then Exit;
+
+  NWritten:= 0;
+  for i:= 0 to List.Count-1 do
+  begin
+    N:= List[i];
+    case AKind of
+      TATWrapStructOpKind.Inserted:
+        if N>=ALine then
+          Inc(N, ACount);
+      TATWrapStructOpKind.Deleted:
+        begin
+          if (N>=ALine) and (N<ALine+ACount) then
+            Continue; //line is deleted
+          if N>=ALine+ACount then
+            Dec(N, ACount);
+        end;
+    end;
+    List[NWritten]:= N;
+    Inc(NWritten);
+  end;
+  while List.Count>NWritten do
+    List.Delete(List.Count-1);
+end;
+
+procedure TATStrings.WrapStructClear;
+var
+  i: integer;
+begin
+  for i:= 0 to High(FWrapStructOps) do
+    SetLength(FWrapStructOps[i].Hashes, 0);
+  FWrapStructOps:= nil;
+  FWrapStructComplex:= false;
+end;
+
+procedure TATStrings.WrapStructInvalidate;
+begin
+  WrapStructClear;
+  FWrapStructComplex:= true;
+end;
+
+function TATStrings.GetLineHash(AIndex: SizeInt): QWord;
+{
+FNV-1a hash of the line's raw buffer bytes. Used only to compare identity of
+lines ("is this line the same text as that deleted line?"), so the encoding
+of the buffer doesn't matter, hashing must be just stable and fast.
+}
+var
+  Item: PATStringItem;
+  P: PByte;
+  NLen, i: SizeInt;
+begin
+  Result:= 14695981039346656037;
+  if not IsIndexValid(AIndex) then Exit;
+  Item:= FList.GetItem(AIndex);
+  NLen:= Length(Item^.Buf);
+  if NLen=0 then Exit;
+  P:= Pointer(Item^.Buf);
+  for i:= 1 to NLen do
+  begin
+    Result:= Result xor P^;
+    Result:= Result * 1099511628211;
+    Inc(P);
+  end;
+end;
+
 procedure TATStrings.DoOnChangeBlock(AX1, AY1, AX2, AY2: SizeInt;
   AChange: TATBlockChangeKind; ABlock: TStringList);
 begin
@@ -3820,6 +4128,28 @@ end;
 procedure TATStrings.DoEventChange(AChange: TATLineChangeKind; ALineIndex, AItemCount: SizeInt);
 begin
   if not FEnabledChangeEvents then exit;
+
+  //2026.09: record structural line changes for the incremental WrapInfo update.
+  //Must be done while affected lines are still present for Kind=Deleted
+  //(all "Deleted" events are fired before the physical deletion).
+  //Edited lines are also indexed here: AddUpdatesAction() indexes them only
+  //when undo items are made (AddUndoItem exits when UndoLimit=0), while the
+  //incremental WrapInfo update needs edited-line indexes in any case.
+  case AChange of
+    TATLineChangeKind.Added:
+      WrapStructRecord(TATWrapStructOpKind.Inserted, ALineIndex, AItemCount);
+    TATLineChangeKind.Deleted:
+      WrapStructRecord(TATWrapStructOpKind.Deleted, ALineIndex, AItemCount);
+    TATLineChangeKind.Edited:
+      if not FWrapStructComplex then
+        if IsIndexValid(ALineIndex) then
+        begin
+          if IndexesOfEditedLines.IndexOf(ALineIndex)<0 then
+            IndexesOfEditedLines.Add(ALineIndex);
+          if IndexesOfEditedLines.Count>ATEditorOptions.MaxUpdatesCountEasy then
+            WrapStructInvalidate;
+        end;
+  end;
 
   FGaps.Update(AChange, ALineIndex, AItemCount);
 

--- a/atsynedit/atstrings_editing.inc
+++ b/atsynedit/atstrings_editing.inc
@@ -310,6 +310,20 @@ begin
   //----------------------
   //Insert multi-line text
 
+  {
+  2026.09: multi-line TextInsert (paste) is not handled by the incremental
+  WrapInfo update (WrapStruct tracking is marked "complex", so next
+  UpdateWrapInfo() fully recalculates): TextInsert combines several line
+  mutations, and its coalesced event (Added, AY, AShift.Y) is fired after the
+  mutations, while WrapStructRecord() must know structural ops before the
+  physical line moves, to shift edited-line indexes correctly. Paste worked
+  with full WrapInfo recalculation before 2026.09 too (any Insert action
+  disabled the cached update), so this is not a regression.
+  Block-insertions of replace_lines (LineBlockInsert) and undo/redo runs are
+  handled incrementally.
+  }
+  WrapStructInvalidate;
+
   Block:= TATStrings.Create(0); //set UndoLimit=0 to avoid undo in Block
   try
     FChangeBlockActive:= true;
@@ -704,10 +718,21 @@ begin
         Item^.Line, Item^.LineEnds, Item^.LineState, FCommandCode,
         CurCarets, CurCarets2, CurMarkers, CurMarkers2, CurAttribs);
     end;
-  end;
-  if bFast then
+
+    //2026.09: fire event before the physical deletion, like LineDelete() does;
+    //WrapStructRecord() needs the deleted lines to be still present
+    //(it hashes their texts, to reuse wrap-items on undo)
+    DoEventLog(ALine1);
+    DoEventChange(TATLineChangeKind.Deleted, ALine1, ALine2-ALine1+1);
+
     FList.DeleteRange(ALine1, ALine2)
+  end
   else
+  begin
+    //2026.09: event before deletion, same reason as above
+    DoEventLog(ALine1);
+    DoEventChange(TATLineChangeKind.Deleted, ALine1, ALine2-ALine1+1);
+
     //delete slowly with undo; yes, we do it for any count of deleted lines
     for i:= ALine2 downto ALine1 do
       LineDelete(i,
@@ -715,6 +740,7 @@ begin
         false{WithEvent},
         true{AWithUndo}
         );
+  end;
 
   (*
   if (ALine2-ALine1)<FUndoList.MaxCount then
@@ -735,8 +761,6 @@ begin
   if AForceLast then
     ActionAddFakeLineIfNeeded;
 
-  DoEventChange(TATLineChangeKind.Deleted, ALine1, ALine2-ALine1+1);
-  DoEventLog(ALine1);
   Modified:= true;
 
   FChangeBlockActive:= false;
@@ -771,6 +795,13 @@ begin
   bFast:= (ANewLines.Count>1) and
     IsIndexValid(ALineFrom);
 
+  //2026.09: fire event before the physical insertion, like LineInsert() does:
+  //WrapStructRecord() must shift edited-line indexes before lines are moved
+  //(SetLine calls, which caller TextReplaceLines_UTF8 makes after this, must
+  //record edited-line indexes already in the new coordinates)
+  DoEventLog(ALineFrom);
+  DoEventChange(TATLineChangeKind.Added, ALineFrom, ANewLines.Count);
+
   if bFast then
   begin
     FList.InsertRange(ALineFrom, ANewLines.Count);
@@ -797,9 +828,6 @@ begin
       LineInsert(ALineFrom, UTF8Decode(ANewLines[i]), false{AWithEvent});
 
   FChangeBlockActive:= false;
-
-  DoEventLog(ALineFrom);
-  DoEventChange(TATLineChangeKind.Added, ALineFrom, ANewLines.Count);
 end;
 
 

--- a/atsynedit/atstrings_editing.inc
+++ b/atsynedit/atstrings_editing.inc
@@ -620,6 +620,9 @@ var
   NCount, i: SizeInt;
   bFast: boolean;
   Item: PATStringItem;
+  CurCarets, CurCarets2: TATPointPairArray;
+  CurMarkers, CurMarkers2: TATMarkerMarkerArray;
+  CurAttribs: TATMarkerAttribArray;
   //CurUndoList: TATUndoList;
   //NNeedUndoCapacity: integer;
 begin
@@ -664,6 +667,11 @@ begin
   original index, text/ends/state), reading them from the intact list,
   then removes all lines with a single FList.DeleteRange() - one memory-move
   of the lines below the block.
+  Carets/markers/attribs are captured once for the whole block, and passed to
+  AddUndoItemEx() per line: old code captured the same values per line (loop
+  fires no events, so editor state doesn't change in it), but each capture was
+  3 event-callbacks into the editor (OnGetCaretsArray allocates an array in
+  TATSynEdit.GetCaretsArray), which dominated the delete time of big blocks.
   Undo/redo results are identical: per-item undo of these items
   (LineInsertRaw at each item's index) is unchanged, and such runs of
   consecutive-index items are optimized too (see UndoCountRun/UndoRun*
@@ -672,13 +680,31 @@ begin
   bFast:= (ALine2-ALine1>0) and (ALine1>=0) and (not FReadOnly);
 
   if bFast then
+  begin
+    //capture once for all undo-items of the block (same values as per-line capture)
+    if FEnabledCaretsInUndo then
+    begin
+      CurCarets:= GetCaretsArray;
+      CurCarets2:= GetCaretsArray2;
+    end
+    else
+    begin
+      CurCarets:= nil;
+      CurCarets2:= nil;
+    end;
+    CurMarkers:= GetMarkersArray;
+    CurMarkers2:= GetMarkersArray2;
+    CurAttribs:= GetAttribsArray;
+
     for i:= ALine2 downto ALine1 do
     begin
       Item:= FList.GetItem(i);
       UpdateModified;
-      AddUndoItem(TATEditAction.Delete, i,
-        Item^.Line, Item^.LineEnds, Item^.LineState, FCommandCode);
+      AddUndoItemEx(TATEditAction.Delete, i,
+        Item^.Line, Item^.LineEnds, Item^.LineState, FCommandCode,
+        CurCarets, CurCarets2, CurMarkers, CurMarkers2, CurAttribs);
     end;
+  end;
   if bFast then
     FList.DeleteRange(ALine1, ALine2)
   else

--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -831,6 +831,7 @@ type
     FOnEnabledUndoRedoChanged: TATSynEditEnabledUndoRedoChanged;
     FOnUndoTooLongLine: TATSynEditUndoTooLongLineEvent;
     FWrapInfo: TATWrapInfo;
+    FWrapUpdateCache: TATWrapUpdateCache; //2026.09: wrap-items of recently deleted lines, restored on undo
     FWrapTemps: TATWrapItems;
     FWrapMode: TATEditorWrapMode;
     FWrapModeOnForMargin: boolean; //on toggling off->on - activate "by window or margin" mode
@@ -2717,7 +2718,9 @@ var
   TempWrapItem: TATWrapItem;
   bUseCachedUpdate: boolean;
   bConsiderFolding: boolean;
+  bParamsChanged: boolean;
   NNewVisibleColumns: integer;
+  NWrapColumnNew: integer;
   NIndentMaximal: integer;
   NLine, NLinesCount, NIndexFrom, NIndexTo: integer;
   i, j: integer;
@@ -2772,20 +2775,90 @@ begin
 
   if not FWrapUpdateNeeded then Exit;
   FWrapUpdateNeeded:= false;
-  FWrapInfo.VisibleColumns:= NNewVisibleColumns;
 
+  //2026.09: detect wrap params change BEFORE overwriting them in FWrapInfo;
+  //with changed params (e.g. window resize, wrap mode change) all wrap-items
+  //must be recalculated, incremental update cannot be used
   case FWrapMode of
     TATEditorWrapMode.ModeOff:
-      FWrapInfo.WrapColumn:= 0;
+      NWrapColumnNew:= 0;
     TATEditorWrapMode.ModeOn:
-      FWrapInfo.WrapColumn:= Max(ATEditorOptions.MinWrapColumn, NNewVisibleColumns-FWrapAddSpace);
+      NWrapColumnNew:= Max(ATEditorOptions.MinWrapColumn, NNewVisibleColumns-FWrapAddSpace);
     TATEditorWrapMode.AtWindowOrMargin:
       begin
         if FMarginRight>=0 then
-          FWrapInfo.WrapColumn:= Max(ATEditorOptions.MinWrapColumn, Min(NNewVisibleColumns-FWrapAddSpace, FMarginRight))
+          NWrapColumnNew:= Max(ATEditorOptions.MinWrapColumn, Min(NNewVisibleColumns-FWrapAddSpace, FMarginRight))
         else
-          FWrapInfo.WrapColumn:= Max(ATEditorOptions.MinWrapColumn, NNewVisibleColumns+FMarginRight);
+          NWrapColumnNew:= Max(ATEditorOptions.MinWrapColumn, NNewVisibleColumns+FMarginRight);
       end;
+  end;
+  bParamsChanged:= (FWrapInfo.VisibleColumns<>NNewVisibleColumns) or
+    (FWrapInfo.WrapColumn<>NWrapColumnNew);
+
+  FWrapInfo.VisibleColumns:= NNewVisibleColumns;
+  FWrapInfo.WrapColumn:= NWrapColumnNew;
+
+  {
+  2026.09: performance fix (word-wrap).
+  1) Incremental update: TATStrings recorded structural line ops
+     (line blocks inserted/deleted) since the previous call, and
+     ATWrapInfo_ApplyStructOps() applies them to WrapInfo with only
+     O(total items) index shifts + wrap calculation for new lines.
+     For UNDO of a big deleted block, wrap-items are restored from
+     FWrapUpdateCache (verified by line text hashes), i.e. no wrap
+     calculation at all. Before this, ANY line Insert/Delete action
+     made the full recalculation of WrapInfo for ALL document lines
+     (AddUpdatesAction() sets EnableCachedWrapinfoUpdate:=false for
+     such actions), e.g. 300K-lines doc: DEL of 200K lines was ~6.4s,
+     UNDO of it was ~19-60s with word-wrap enabled.
+  2) "Nothing changed" skip: FWrapUpdateNeeded can be set by calls
+     which don't change the text (e.g. Update(true) of the undo-pause,
+     DoCommandResults of caret-only commands); when no structural ops
+     and no edited lines are recorded, and line count matches, full
+     recalculation is not needed at all.
+  }
+  if AAllowCachedUpdate and (not bParamsChanged) then
+  begin
+    if (not CurStrings.WrapStructComplex) and
+      (FWrapInfo.StringsPrevCount>=0) and
+      (Length(CurStrings.WrapStructOps)>0) then
+    begin
+      if ATWrapInfo_ApplyStructOps(
+        CurStrings,
+        FWrapInfo,
+        FWrapTemps,
+        CurStrings.WrapStructOps,
+        FWrapUpdateCache,
+        FTabHelper,
+        FEditorIndex,
+        FWrapInfo.WrapColumn,
+        NNewVisibleColumns,
+        NIndentMaximal,
+        FWrapIndented,
+        FOptNonWordChars,
+        bConsiderFolding,
+        FFontProportional) then
+      begin
+        FWrapInfo.StringsPrevCount:= NLinesCount;
+        CurStrings.IndexesOfEditedLines.Clear;
+        CurStrings.EnableCachedWrapinfoUpdate:= true;
+        CurStrings.WrapStructClear;
+        Exit
+      end
+      else
+      begin
+        //cannot apply ops: fall to the full recalculation below
+      end;
+    end
+    else
+    if (not CurStrings.WrapStructComplex) and
+      (Length(CurStrings.WrapStructOps)=0) and
+      (CurStrings.IndexesOfEditedLines.Count=0) and
+      (FWrapInfo.StringsPrevCount=NLinesCount) then
+    begin
+      //nothing changed since the previous WrapInfo update
+      Exit
+    end;
   end;
 
   bUseCachedUpdate:=
@@ -2802,6 +2875,7 @@ begin
   if not bUseCachedUpdate then
   begin
     FWrapInfo.Clear;
+    FWrapUpdateCache.Clear; //2026.09: cached items are not related to the recalculated WrapInfo anymore
     FWrapInfo.SetCapacity(NLinesCount);
     for i:= 0 to NLinesCount-1 do
     begin
@@ -2860,6 +2934,7 @@ begin
   FWrapInfo.StringsPrevCount:= CurStrings.Count;
   CurStrings.IndexesOfEditedLines.Clear;
   CurStrings.EnableCachedWrapinfoUpdate:= true;
+  CurStrings.WrapStructClear; //2026.09: WrapInfo is recalculated/repaired, forget recorded ops
 
   {$ifdef debug_findwrapindex}
   DebugFindWrapIndex;
@@ -2867,114 +2942,12 @@ begin
 end;
 
 
-procedure _CalcWrapInfos(
-  AStrings: TATStrings;
-  ATabHelper: TATStringTabHelper;
-  AEditorIndex: integer;
-  AWrapColumn: integer;
-  AWrapIndented: boolean;
-  AVisibleColumns: integer;
-  const ANonWordChars: atString;
-  ALineIndex: integer;
-  AIndentMaximal: integer;
-  AItems: TATWrapItems;
-  AConsiderFolding: boolean;
-  AFontProportional: boolean);
-var
-  WrapItem: TATWrapItem;
-  WrapItemPtr: PATWrapItem;
-  NLineLen, NPartLen, NFoldFrom: integer;
-  NPartOffset, NIndent, NVisColumns: integer;
-  bInitialItem: boolean;
-  StrPart: UnicodeString;
-begin
-  AItems.Clear;
-
-  //line folded entirely?
-  if AConsiderFolding then
-    if AStrings.LinesHidden[ALineIndex, AEditorIndex] then Exit;
-
-  NLineLen:= AStrings.LinesLen[ALineIndex];
-
-  if NLineLen=0 then
-  begin
-    WrapItem.Init(ALineIndex, 1, 0, 0, TATWrapItemFinal.Final, true);
-    AItems.Add(WrapItem);
-    Exit;
-  end;
-
-  //consider fold, before wordwrap
-  if AConsiderFolding then
-  begin
-    //line folded partially?
-    NFoldFrom:= AStrings.LinesFoldFrom[ALineIndex, AEditorIndex];
-    if NFoldFrom>0 then
-    begin
-      WrapItem.Init(ALineIndex, 1, Min(NLineLen, NFoldFrom-1), 0, TATWrapItemFinal.Collapsed, true);
-      AItems.Add(WrapItem);
-      Exit;
-    end;
-  end;
-
-  //line not wrapped?
-  if (AWrapColumn<ATEditorOptions.MinWrapColumnAbs) then
-  begin
-    WrapItem.Init(ALineIndex, 1, NLineLen, 0, TATWrapItemFinal.Final, true);
-    AItems.Add(WrapItem);
-    Exit;
-  end;
-
-  NVisColumns:= Max(AVisibleColumns, ATEditorOptions.MinWrapColumnAbs);
-  NPartOffset:= 1;
-  NIndent:= 0;
-  bInitialItem:= true;
-
-  repeat
-    if AFontProportional then
-      StrPart:= AStrings.LineSub(ALineIndex, NPartOffset, ATEditorOptions.MaxVisibleColumns)
-    else
-      StrPart:= AStrings.LineSub(ALineIndex, NPartOffset, NVisColumns);
-
-    if StrPart='' then
-    begin
-      if not bInitialItem then
-      begin
-        WrapItemPtr:= AItems._GetItemPtr(AItems.Count-1);
-        WrapItemPtr^.NFinal:= TATWrapItemFinal.Final;
-      end;
-      Break;
-    end;
-
-    NPartLen:= ATabHelper.FindWordWrapOffset(
-      ALineIndex,
-      //very slow to calc for entire line (eg len=70K),
-      //calc for first NVisColumns chars
-      StrPart,
-      Max(AWrapColumn-NIndent, ATEditorOptions.MinWrapColumnAbs),
-      ANonWordChars,
-      AWrapIndented
-      );
-
-    WrapItem.Init(ALineIndex, NPartOffset, NPartLen, NIndent, TATWrapItemFinal.Middle, bInitialItem);
-    AItems.Add(WrapItem);
-    bInitialItem:= false;
-
-    if AWrapIndented then
-      if NPartOffset=1 then
-      begin
-        NIndent:= ATabHelper.GetIndentExpanded(ALineIndex, StrPart);
-        NIndent:= Min(NIndent, AIndentMaximal);
-      end;
-
-    Inc(NPartOffset, NPartLen);
-  until false;
-end;
-
-
 procedure TATSynEdit.DoCalcWrapInfos(ALine: integer; AIndentMaximal: integer; AItems: TATWrapItems;
   AConsiderFolding: boolean);
 begin
-  _CalcWrapInfos(
+  //2026.09: calculation is moved to ATSynEdit_WrapInfo.ATWrapInfo_CalcLine(),
+  //to be usable by the incremental WrapInfo update too
+  ATWrapInfo_CalcLine(
     Strings,
     FTabHelper,
     FEditorIndex,
@@ -5604,6 +5577,8 @@ begin
   FWrapInfo.StringsObj:= FStringsInt;
   FWrapInfo.WrapColumn:= cInitMarginRight;
 
+  FWrapUpdateCache:= TATWrapUpdateCache.Create;
+
   FWrapTemps:= TATWrapItems.Create;
   FWrapUpdateNeeded:= true;
   FWrapMode:= cInitWrapMode;
@@ -5984,6 +5959,7 @@ begin
     FreeAndNil(FAttribs);
   FreeAndNil(FGutter);
   FreeAndNil(FWrapTemps);
+  FreeAndNil(FWrapUpdateCache);
   FreeAndNil(FWrapInfo);
   FreeAndNil(FStringsInt);
   if Assigned(FGutterDecor) then

--- a/atsynedit/atsynedit_cmd_misc.inc
+++ b/atsynedit/atsynedit_cmd_misc.inc
@@ -210,6 +210,7 @@ var
 begin
   St:= Strings;
   ALineTo:= Min(ALineTo, St.Count-1);
+  St.WrapStructInvalidate; //2026.09: hidden-lines map is changed: WrapInfo must be fully recalculated
 
   for i:= ALineFrom to ALineTo do
   begin

--- a/atsynedit/atsynedit_fgl.pas
+++ b/atsynedit/atsynedit_fgl.pas
@@ -72,6 +72,7 @@ type
     procedure Clear;
     procedure Delete(Index: Integer);
     procedure DeleteRange(IndexFrom, IndexTo : Integer);
+    procedure InsertRange(AIndex, ACount: Integer);
     class procedure Error(const Msg: string; Data: PtrInt);
     procedure Exchange(Index1, Index2: Integer);
     function Expand: TFPSList;
@@ -627,6 +628,40 @@ begin
     on the list, and accidentally Deref it too soon.
     See http://bugs.freepascal.org/view.php?id=20005. }
   FillChar(InternalItems[FCount]^, (FCapacity+1-FCount) * FItemSize, #0);
+end;
+
+procedure TFPSList.InsertRange(AIndex, ACount: Integer);
+{
+2026.09: opens ACount empty slots at AIndex, with a single memory-move of the
+list tail. Slots are zeroed = empty items, like TFPSList.Insert() leaves its
+inserted slot (list keeps 'ending filled with zeros' invariant).
+Same effect as ACount of Insert() calls, but O(Count) list-work instead of
+O(Count*ACount). Made for the incremental WrapInfo update: splicing
+wrap-items of inserted lines into TATWrapItems (also used by
+TATStringItemList.InsertRange logic before).
+}
+var
+  Ptr: PByte;
+begin
+  if ACount<=0 then Exit;
+  if (AIndex<0) or (AIndex>FCount) then
+    RaiseIndexError(AIndex);
+
+  if FCount+ACount>FCapacity then
+    SetCapacity(FCount+ACount);
+
+  if AIndex<FCount then
+  begin
+    Ptr:= PByte(InternalItems[AIndex]);
+    //move list tail to the right; region after Count is zeroed by SetCapacity,
+    //so it's safe to move to (Ptr+ACount*ItemSize)
+    System.Move(Ptr^, (Ptr+Int64(ACount)*FItemSize)^, Int64(FCount-AIndex)*FItemSize);
+    //zero opened slots: empty items, like Insert() does
+    System.FillChar(Ptr^, Int64(ACount)*FItemSize, 0);
+  end;
+  //note: for AIndex=Count (append) slots are already zeroed: list keeps
+  //'ending filled with zeros' invariant
+  Inc(FCount, ACount);
 end;
 
 procedure TFPSList.Extract(Item: Pointer; ResultPtr: Pointer);

--- a/atsynedit/atsynedit_fold.inc
+++ b/atsynedit/atsynedit_fold.inc
@@ -88,8 +88,9 @@ begin
   RngOuter:= Fold.ItemPtr(ARangeIndex);
   RngOuter^.Folded:= false;
   FWrapUpdateNeeded:= true;
-
+  //2026.09: hidden-lines map is changed: WrapInfo must be fully recalculated
   Strs:= Strings;
+  Strs.WrapStructInvalidate;
   RangeIndexes:= FFold.FindRanges(ARangeIndex, true{OnlyFolded}, true{TopLevel});
 
   //show all lines not in found _folded_ subranges
@@ -133,6 +134,7 @@ begin
   Range:= Fold.ItemPtr(ARangeIndex);
   Range^.Folded:= true;
   FWrapUpdateNeeded:= true;
+  St.WrapStructInvalidate; //2026.09: hidden-lines map is changed: WrapInfo must be fully recalculated
 
   //partially hide first line
   case FFoldStyle of
@@ -279,6 +281,7 @@ begin
   St:= Strings;
   NMaxLine:= St.Count-1;
   if NMaxLine<0 then exit;
+  St.WrapStructInvalidate; //2026.09: hidden-lines map is recalculated: WrapInfo must be fully recalculated too
 
   for iRange:= 0 to Fold.Count-1 do
   begin

--- a/atsynedit/atsynedit_wrapinfo.pas
+++ b/atsynedit/atsynedit_wrapinfo.pas
@@ -13,8 +13,15 @@ interface
 
 uses
   Classes, SysUtils,
+  ATStringProc,
   ATStrings,
   ATSynEdit_fgl;
+
+const
+  ATWrapInfo_MaxCacheLines = 1024*1024;
+    //2026.09: hard cap of lines in the wrap-items restore cache
+    //(hashes + items of deleted lines, to make undo of big blocks fast);
+    //memory: 8 bytes per line hash + 16 bytes per wrap-item
 
 type
   TATWrapItemFinal = (
@@ -74,13 +81,86 @@ type
     function FindIndexOfCaretPos(APos: TPoint): integer;
     procedure SetCapacity(AValue: integer);
     procedure ReplaceItems(AFrom, ATo: integer; AItems: TATWrapItems);
+
+    //2026.09: primitives for the incremental WrapInfo update
+    function FindItemIndexForLineGe(ALine: SizeInt): integer; //first item index with NLineIndex>=ALine; Count when none
+    procedure DeleteItems(AFrom, ATo: integer); //remove items [AFrom..ATo], single memory-move
+    procedure SpliceItems(AIndex: integer; AItems: TATWrapItems); //insert all AItems at AIndex, single memory-move
+    procedure ShiftLineIndexes(AFromItem: integer; ADelta: SizeInt); //Inc(NLineIndex, ADelta) for items [AFromItem..]
   end;
+
+type
+  { TATWrapUpdateCache }
+
+  {
+  2026.09: performance fix (word-wrap). Cache of wrap-items of recently deleted
+  lines. When a big block of lines is deleted (e.g. DEL with big selection),
+  wrap-items of its lines are copied here with per-line text hashes. When the
+  same lines are re-inserted on UNDO (or REDO), items are restored from the
+  cache, instead of re-calculating the wrap for each line (which is the most
+  expensive part: per-char word-boundary and width calculations).
+  Restoration is verified by 64-bit hashes of line texts, so any other
+  inserted block (same position/count but different texts) never reuses
+  stale items: hashes don't match, and the slow per-line calculation runs.
+  Cache is cleared: on full WrapInfo recalculation, on wrap params change,
+  on folding changes (folded lines have no wrap-items, so cached items
+  don't match the unfolded restored lines).
+  }
+  TATWrapUpdateCache = class
+  private
+    function GetLineCount: integer;
+  public
+    WrapColumn: integer; //wrap params at the cache fill time
+    VisibleColumns: integer;
+    Hashes: array of QWord; //per cached line, cache-local index 0..N-1
+    Items: TATWrapItems; //items of cached lines, NLineIndex is cache-local line index
+    constructor Create; virtual;
+    destructor Destroy; override;
+    procedure Clear;
+    property LineCount: integer read GetLineCount;
+    procedure Populate(AWrapInfo: TATWrapInfo; ADeleteFrom, ADeleteCount: SizeInt;
+      const AHashes: array of QWord; AHashesAll: boolean;
+      AWrapColumn, AVisibleColumns: integer);
+    function TryRestore(const ACurHashes: array of QWord;
+      AInsertLine, AInsertCount: SizeInt;
+      AWrapColumn, AVisibleColumns: integer;
+      AOutItems: TATWrapItems): boolean;
+  end;
+
+procedure ATWrapInfo_CalcLine(
+  AStrings: TATStrings;
+  ATabHelper: TATStringTabHelper;
+  AEditorIndex: integer;
+  AWrapColumn: integer;
+  AWrapIndented: boolean;
+  AVisibleColumns: integer;
+  const ANonWordChars: atString;
+  ALineIndex: integer;
+  AIndentMaximal: integer;
+  AItems: TATWrapItems;
+  AConsiderFolding: boolean;
+  AFontProportional: boolean);
+
+function ATWrapInfo_ApplyStructOps(
+  AStrings: TATStrings;
+  AWrapInfo: TATWrapInfo;
+  ATempItems: TATWrapItems;
+  const AOps: TATWrapStructOpArray;
+  ACache: TATWrapUpdateCache;
+  ATabHelper: TATStringTabHelper;
+  AEditorIndex: integer;
+  AWrapColumn, AVisibleColumns, AIndentMaximal: integer;
+  AWrapIndented: boolean;
+  const ANonWordChars: atString;
+  AConsiderFolding: boolean;
+  AFontProportional: boolean): boolean;
 
 
 implementation
 
 uses
-  Math, Dialogs, Forms;
+  Math, Dialogs, Forms,
+  ATSynEdit_Globals;
 
 { TATWrapItem }
 
@@ -306,6 +386,539 @@ begin
   //overwrite N items
   for i:= 0 to AItems.Count-1 do
     FList[AFrom+i]:= AItems[i];
+end;
+
+
+{ TATWrapInfo: primitives for the incremental update }
+
+function TATWrapInfo.FindItemIndexForLineGe(ALine: SizeInt): integer;
+var
+  a, b, m: integer;
+begin
+  if FVirtualMode then
+    Exit(Max(0, Min(ALine, FStrings.Count)));
+
+  //binary search of lower bound: first item with NLineIndex>=ALine
+  a:= 0;
+  b:= FList.Count;
+  while a<b do
+  begin
+    m:= (a+b) div 2;
+    if FList._GetItemPtr(m)^.NLineIndex < ALine then
+      a:= m+1
+    else
+      b:= m;
+  end;
+  Result:= a;
+end;
+
+procedure TATWrapInfo.DeleteItems(AFrom, ATo: integer);
+begin
+  if FVirtualMode then exit;
+  if (AFrom<0) or (AFrom>ATo) or (ATo>=FList.Count) then exit;
+  FList.DeleteRange(AFrom, ATo);
+end;
+
+procedure TATWrapInfo.SpliceItems(AIndex: integer; AItems: TATWrapItems);
+var
+  i: integer;
+begin
+  if FVirtualMode then exit;
+  if AItems=nil then exit;
+  if AItems.Count=0 then exit;
+
+  if (AIndex<0) or (AIndex>FList.Count) then
+    AIndex:= FList.Count;
+
+  FList.InsertRange(AIndex, AItems.Count);
+  for i:= 0 to AItems.Count-1 do
+    FList._GetItemPtr(AIndex+i)^:= AItems._GetItemPtr(i)^;
+end;
+
+procedure TATWrapInfo.ShiftLineIndexes(AFromItem: integer; ADelta: SizeInt);
+var
+  i: integer;
+begin
+  if FVirtualMode then exit;
+  if ADelta=0 then exit;
+  for i:= Max(0, AFromItem) to FList.Count-1 do
+    FList._GetItemPtr(i)^.NLineIndex+= ADelta;
+end;
+
+
+{ TATWrapUpdateCache }
+
+function TATWrapUpdateCache.GetLineCount: integer;
+begin
+  Result:= Length(Hashes);
+end;
+
+constructor TATWrapUpdateCache.Create;
+begin
+  Items:= TATWrapItems.Create;
+end;
+
+destructor TATWrapUpdateCache.Destroy;
+begin
+  Clear;
+  FreeAndNil(Items);
+  inherited;
+end;
+
+procedure TATWrapUpdateCache.Clear;
+begin
+  SetLength(Hashes, 0);
+  if Items<>nil then
+    Items.Clear;
+end;
+
+procedure TATWrapUpdateCache.Populate(AWrapInfo: TATWrapInfo; ADeleteFrom, ADeleteCount: SizeInt;
+  const AHashes: array of QWord; AHashesAll: boolean;
+  AWrapColumn, AVisibleColumns: integer);
+var
+  iFrom, iTo, i: integer;
+  Item: TATWrapItem;
+begin
+  Clear;
+  if not AHashesAll then Exit;
+  if ADeleteCount<=0 then Exit;
+  if ADeleteCount>ATWrapInfo_MaxCacheLines then Exit;
+  if ADeleteCount<>Length(AHashes) then Exit;
+
+  WrapColumn:= AWrapColumn;
+  VisibleColumns:= AVisibleColumns;
+
+  SetLength(Hashes, ADeleteCount);
+  for i:= 0 to ADeleteCount-1 do
+    Hashes[i]:= AHashes[i];
+
+  //copy wrap-items of deleted lines, with cache-local line indexes
+  iFrom:= AWrapInfo.FindItemIndexForLineGe(ADeleteFrom);
+  iTo:= AWrapInfo.FindItemIndexForLineGe(ADeleteFrom+ADeleteCount)-1;
+  if iTo>=iFrom then
+    for i:= iFrom to iTo do
+    begin
+      Item:= AWrapInfo.Data[i];
+      Dec(Item.NLineIndex, ADeleteFrom);
+      Items.Add(Item);
+    end;
+end;
+
+function TATWrapUpdateCache.TryRestore(const ACurHashes: array of QWord;
+  AInsertLine, AInsertCount: SizeInt;
+  AWrapColumn, AVisibleColumns: integer;
+  AOutItems: TATWrapItems): boolean;
+{
+ACurHashes[]: hashes of current document lines, which the AInsertLine..AInsertLine+AInsertCount-1
+op inserts (caller computes them at FINAL document positions). When they match a sub-range of
+cached Hashes[], wrap-items of that sub-range are restored to AOutItems, with line indexes
+in "insert-op" coordinates (AInsertLine + offset), so the caller's sequential application
+shifts them correctly.
+}
+var
+  K0, K, i, j, d: SizeInt;
+  bMatch: boolean;
+  NWrite: integer;
+  Item: TATWrapItem;
+begin
+  Result:= false;
+  if AOutItems=nil then Exit;
+  AOutItems.Clear;
+
+  K0:= Length(Hashes);
+  if K0=0 then Exit;
+  if (WrapColumn<>AWrapColumn) or (VisibleColumns<>AVisibleColumns) then Exit;
+  K:= AInsertCount;
+  if (K<=0) or (K>K0) then Exit;
+  if Length(ACurHashes)<>K then Exit;
+
+  //find the offset of ACurHashes inside cached Hashes
+  d:= -1;
+  for i:= 0 to K0-K do
+    if Hashes[i]=ACurHashes[0] then
+    begin
+      bMatch:= true;
+      for j:= 1 to K-1 do
+        if Hashes[i+j]<>ACurHashes[j] then
+        begin
+          bMatch:= false;
+          Break
+        end;
+      if bMatch then
+      begin
+        d:= i;
+        Break
+      end;
+    end;
+  if d<0 then Exit;
+
+  //extract items of matched lines, with line indexes of the inserted block
+  for i:= 0 to Items.Count-1 do
+  begin
+    Item:= Items[i];
+    if (Item.NLineIndex>=d) and (Item.NLineIndex<d+K) then
+    begin
+      Item.NLineIndex:= AInsertLine + (Item.NLineIndex-d);
+      AOutItems.Add(Item);
+    end;
+  end;
+
+  //trim the cache: drop the consumed lines
+  if (d=0) and (K=K0) then
+    Clear
+  else
+  if d=0 then
+  begin
+    //prefix consumed: drop first K lines, shift the rest
+    for i:= K to K0-1 do
+      Hashes[i-K]:= Hashes[i];
+    SetLength(Hashes, K0-K);
+    NWrite:= 0;
+    for i:= 0 to Items.Count-1 do
+      if Items[i].NLineIndex>=K then
+      begin
+        Item:= Items[i];
+        Dec(Item.NLineIndex, K);
+        Items[NWrite]:= Item;
+        Inc(NWrite);
+      end;
+    while Items.Count>NWrite do
+      Items.Delete(Items.Count-1);
+  end
+  else
+  if d+K=K0 then
+  begin
+    //suffix consumed: drop last K lines
+    SetLength(Hashes, K0-K);
+    NWrite:= 0;
+    for i:= 0 to Items.Count-1 do
+      if Items[i].NLineIndex<K0-K then
+      begin
+        Items[NWrite]:= Items[i];
+        Inc(NWrite);
+      end;
+    while Items.Count>NWrite do
+      Items.Delete(Items.Count-1);
+  end
+  else
+    //middle consumed: don't support split cache, drop it all
+    Clear;
+
+  Result:= true;
+end;
+
+
+{ ATWrapInfo_CalcLine }
+
+procedure ATWrapInfo_CalcLine(
+  AStrings: TATStrings;
+  ATabHelper: TATStringTabHelper;
+  AEditorIndex: integer;
+  AWrapColumn: integer;
+  AWrapIndented: boolean;
+  AVisibleColumns: integer;
+  const ANonWordChars: atString;
+  ALineIndex: integer;
+  AIndentMaximal: integer;
+  AItems: TATWrapItems;
+  AConsiderFolding: boolean;
+  AFontProportional: boolean);
+var
+  WrapItem: TATWrapItem;
+  WrapItemPtr: PATWrapItem;
+  NLineLen, NPartLen, NFoldFrom: integer;
+  NPartOffset, NIndent, NVisColumns: integer;
+  bInitialItem: boolean;
+  StrPart: UnicodeString;
+begin
+  AItems.Clear;
+
+  //line folded entirely?
+  if AConsiderFolding then
+    if AStrings.LinesHidden[ALineIndex, AEditorIndex] then Exit;
+
+  NLineLen:= AStrings.LinesLen[ALineIndex];
+
+  if NLineLen=0 then
+  begin
+    WrapItem.Init(ALineIndex, 1, 0, 0, TATWrapItemFinal.Final, true);
+    AItems.Add(WrapItem);
+    Exit;
+  end;
+
+  //consider fold, before wordwrap
+  if AConsiderFolding then
+  begin
+    //line folded partially?
+    NFoldFrom:= AStrings.LinesFoldFrom[ALineIndex, AEditorIndex];
+    if NFoldFrom>0 then
+    begin
+      WrapItem.Init(ALineIndex, 1, Min(NLineLen, NFoldFrom-1), 0, TATWrapItemFinal.Collapsed, true);
+      AItems.Add(WrapItem);
+      Exit;
+    end;
+  end;
+
+  //line not wrapped?
+  if (AWrapColumn<ATEditorOptions.MinWrapColumnAbs) then
+  begin
+    WrapItem.Init(ALineIndex, 1, NLineLen, 0, TATWrapItemFinal.Final, true);
+    AItems.Add(WrapItem);
+    Exit;
+  end;
+
+  NVisColumns:= Max(AVisibleColumns, ATEditorOptions.MinWrapColumnAbs);
+  NPartOffset:= 1;
+  NIndent:= 0;
+  bInitialItem:= true;
+
+  repeat
+    if AFontProportional then
+      StrPart:= AStrings.LineSub(ALineIndex, NPartOffset, ATEditorOptions.MaxVisibleColumns)
+    else
+      StrPart:= AStrings.LineSub(ALineIndex, NPartOffset, NVisColumns);
+
+    if StrPart='' then
+    begin
+      if not bInitialItem then
+      begin
+        WrapItemPtr:= AItems._GetItemPtr(AItems.Count-1);
+        WrapItemPtr^.NFinal:= TATWrapItemFinal.Final;
+      end;
+      Break;
+    end;
+
+    NPartLen:= ATabHelper.FindWordWrapOffset(
+      ALineIndex,
+      //very slow to calc for entire line (eg len=70K),
+      //calc for first NVisColumns chars
+      StrPart,
+      Max(AWrapColumn-NIndent, ATEditorOptions.MinWrapColumnAbs),
+      ANonWordChars,
+      AWrapIndented
+      );
+
+    WrapItem.Init(ALineIndex, NPartOffset, NPartLen, NIndent, TATWrapItemFinal.Middle, bInitialItem);
+    AItems.Add(WrapItem);
+    bInitialItem:= false;
+
+    if AWrapIndented then
+      if NPartOffset=1 then
+      begin
+        NIndent:= ATabHelper.GetIndentExpanded(ALineIndex, StrPart);
+        NIndent:= Min(NIndent, AIndentMaximal);
+      end;
+
+    Inc(NPartOffset, NPartLen);
+  until false;
+end;
+
+
+{ ATWrapInfo_ApplyStructOps }
+
+function ATWrapInfo_ApplyStructOps(
+  AStrings: TATStrings;
+  AWrapInfo: TATWrapInfo;
+  ATempItems: TATWrapItems;
+  const AOps: TATWrapStructOpArray;
+  ACache: TATWrapUpdateCache;
+  ATabHelper: TATStringTabHelper;
+  AEditorIndex: integer;
+  AWrapColumn, AVisibleColumns, AIndentMaximal: integer;
+  AWrapIndented: boolean;
+  const ANonWordChars: atString;
+  AConsiderFolding: boolean;
+  AFontProportional: boolean): boolean;
+{
+2026.09: performance fix (word-wrap). Applies structural line ops (recorded by
+TATStrings.WrapStructRecord since the last WrapInfo update) to AWrapInfo
+incrementally:
+- for deleted lines: wrap-items of these lines are removed (single
+  memory-move), and line indexes of items below are shifted up; removed items
+  are copied to ACache (with line text hashes), to be restored on undo;
+- for inserted lines: line indexes of items below are shifted down, wrap-items
+  for new lines are calculated (per-line, like the full recalculation does) or
+  restored from ACache (when UNDO re-inserts the same lines, verified by
+  hashes), and spliced in (single memory-move).
+So the cost is O(total wrap-items) for index shifts + O(new lines) for the
+wrap calculation, instead of O(all lines) of the full recalculation. E.g.
+CudaText test (300K lines, wrap on): DEL of 200K lines ~6.4 sec -> ~0.05 sec,
+UNDO of it ~19-60 sec -> ~1 sec.
+Then it recalculates wrap-items for edited lines (TATStrings.IndexesOfEditedLines),
+like the old "cached update" did.
+Returns False when ops cannot be applied (then caller must fully recalculate):
+- no ops and no edited lines;
+- sanity check fails: WrapInfo's StringsPrevCount + net line change <> current
+  line count (some untracked change happened: e.g. document was loaded).
+}
+var
+  NewItems: TATWrapItems;
+  ListNums: TATIntegerList;
+  i, j, k: SizeInt;
+  NCur: SizeInt;
+  NLine, NIndexFrom, NIndexTo, NSplice: integer;
+  bRestored: boolean;
+  FinalPos: array of SizeInt;
+  CurHashes: array of QWord;
+  WrapItem: TATWrapItem;
+begin
+  Result:= false;
+  if (AStrings=nil) or (AWrapInfo=nil) then Exit;
+  if AWrapInfo.VirtualMode then Exit;
+
+  if Length(AOps)=0 then
+    if AStrings.IndexesOfEditedLines.Count=0 then
+      Exit; //nothing to apply
+
+  //sanity: WrapInfo must match the doc state before ops, and all ops must
+  //have valid line ranges (indexes are in "doc state before op" coordinates);
+  //when the check fails (e.g. doc was loaded/replaced, so ops are not valid
+  //anymore), caller must use the full recalculation
+  NCur:= AWrapInfo.StringsPrevCount;
+  if NCur<0 then Exit;
+  for i:= 0 to High(AOps) do
+  begin
+    case AOps[i].Kind of
+      TATWrapStructOpKind.Inserted:
+        begin
+          if (AOps[i].Line<0) or (AOps[i].Line>NCur) then Exit;
+          Inc(NCur, AOps[i].Count);
+        end;
+      TATWrapStructOpKind.Deleted:
+        begin
+          if (AOps[i].Line<0) or (AOps[i].Line+AOps[i].Count>NCur) then Exit;
+          Dec(NCur, AOps[i].Count);
+        end;
+    end;
+  end;
+  if NCur<>AStrings.Count then Exit;
+
+  NewItems:= TATWrapItems.Create;
+  try
+    for i:= 0 to High(AOps) do
+    begin
+      case AOps[i].Kind of
+        TATWrapStructOpKind.Inserted:
+          begin
+            //shift line indexes of items at/below the insertion point
+            NSplice:= AWrapInfo.FindItemIndexForLineGe(AOps[i].Line);
+            AWrapInfo.ShiftLineIndexes(NSplice, AOps[i].Count);
+
+            //map "position after this op" of each new line to its position in
+            //the final document: WrapInfo ops are applied sequentially (item
+            //line indexes are in "after this op" coordinates, later ops shift
+            //them), but the document is already in its final state, so new
+            //lines must be read at their FINAL positions
+            SetLength(FinalPos, AOps[i].Count);
+            for j:= 0 to AOps[i].Count-1 do
+            begin
+              NLine:= AOps[i].Line+j;
+              for k:= i+1 to High(AOps) do
+                case AOps[k].Kind of
+                  TATWrapStructOpKind.Inserted:
+                    if AOps[k].Line<=NLine then
+                      Inc(NLine, AOps[k].Count);
+                  TATWrapStructOpKind.Deleted:
+                    begin
+                      if AOps[k].Line+AOps[k].Count<=NLine then
+                        Dec(NLine, AOps[k].Count)
+                      else
+                      if (AOps[k].Line<=NLine) and (NLine<AOps[k].Line+AOps[k].Count) then
+                        Exit; //line is deleted by a later op: not supported, full recalc
+                    end;
+                end;
+              if (NLine<0) or (NLine>=AStrings.Count) then Exit;
+              FinalPos[j]:= NLine;
+            end;
+
+            //wrap-items for new lines: restore from cache or calculate
+            NewItems.Clear;
+            bRestored:= false;
+            if ACache<>nil then
+              if not AConsiderFolding then
+              begin
+                SetLength(CurHashes, AOps[i].Count);
+                for j:= 0 to AOps[i].Count-1 do
+                  CurHashes[j]:= AStrings.GetLineHash(FinalPos[j]);
+                bRestored:= ACache.TryRestore(CurHashes, AOps[i].Line, AOps[i].Count,
+                  AWrapColumn, AVisibleColumns, NewItems);
+              end;
+
+            if not bRestored then
+              for j:= 0 to AOps[i].Count-1 do
+              begin
+                ATWrapInfo_CalcLine(AStrings, ATabHelper, AEditorIndex,
+                  AWrapColumn, AWrapIndented, AVisibleColumns, ANonWordChars,
+                  FinalPos[j], AIndentMaximal, ATempItems, AConsiderFolding,
+                  AFontProportional);
+                //ATempItems has 1+ items of this line (CalcLine cleared it);
+                //item line index must be "position after this op", not final
+                for k:= 0 to ATempItems.Count-1 do
+                begin
+                  WrapItem:= ATempItems[k];
+                  WrapItem.NLineIndex:= AOps[i].Line+j;
+                  NewItems.Add(WrapItem);
+                end;
+                ATempItems.Clear;
+              end;
+
+            AWrapInfo.SpliceItems(NSplice, NewItems);
+          end;
+
+        TATWrapStructOpKind.Deleted:
+          begin
+            //populate cache: copy items of deleted lines (before removal)
+            if ACache<>nil then
+              if not AConsiderFolding then
+                ACache.Populate(AWrapInfo, AOps[i].Line, AOps[i].Count,
+                  AOps[i].Hashes, AOps[i].HashesAll, AWrapColumn, AVisibleColumns)
+              else
+                ACache.Clear
+            else
+              ; //no cache
+
+            //remove items of deleted lines, shift indexes of items below
+            j:= AWrapInfo.FindItemIndexForLineGe(AOps[i].Line);
+            NIndexTo:= AWrapInfo.FindItemIndexForLineGe(AOps[i].Line+AOps[i].Count)-1;
+            AWrapInfo.DeleteItems(j, NIndexTo);
+            AWrapInfo.ShiftLineIndexes(j, -AOps[i].Count);
+          end;
+      end;
+    end;
+
+    //recalc wrap-items of edited lines (same as the old "cached update" did)
+    if AStrings.IndexesOfEditedLines.Count>0 then
+    begin
+      ListNums:= TATIntegerList.Create;
+      try
+        ListNums.Assign(AStrings.IndexesOfEditedLines);
+        for i:= 0 to ListNums.Count-1 do
+        begin
+          NLine:= ListNums[i];
+          if not AStrings.IsIndexValid(NLine) then Continue;
+
+          ATWrapInfo_CalcLine(AStrings, ATabHelper, AEditorIndex,
+            AWrapColumn, AWrapIndented, AVisibleColumns, ANonWordChars,
+            NLine, AIndentMaximal, ATempItems, AConsiderFolding,
+            AFontProportional);
+          if ATempItems.Count=0 then Continue;
+
+          AWrapInfo.FindIndexesOfLineNumber(NLine, NIndexFrom, NIndexTo);
+          if NIndexFrom>=0 then
+            AWrapInfo.ReplaceItems(NIndexFrom, NIndexTo, ATempItems);
+        end;
+        ATempItems.Clear;
+      finally
+        FreeAndNil(ListNums);
+      end;
+    end;
+
+    Result:= true;
+  finally
+    FinalPos:= nil;
+    CurHashes:= nil;
+    FreeAndNil(NewItems);
+  end;
 end;
 
 


### PR DESCRIPTION


results of this patch:
this enable wrap,  then delete and undo 200k from 300k lines
```python
ed.set_prop(PROP_WRAP,1)
import time, random, cudatext_cmd as c; ed.set_text_all('\n'.join('x'*random.randint(100, 1000) for _ in range(300000))); ed.set_caret(0, 200000, 0, 0); 
t1 = time.time(); ed.cmd(c.cCommand_TextDeleteSelection); t2 = time.time(); print(f"Delete: {t2-t1:.4f}s")
t1 = time.time(); ed.cmd(c.cCommand_Undo); t2 = time.time(); print(f"Undo: {t2-t1:.4f}s")
```

was;
Delete: 6.7174s
Undo: 60.3385s

now:
Delete: 0.5960s
Undo: 0.7960s

____________________________
ai reasoning:
## Root cause (confirmed by both captures)

Word-wrap is indeed the bottleneck — `_CALCWRAPINFOS` dominates everything (24s of the delete capture, 261s of the 267s undo capture). The chain: **any line Insert/Delete action sets `EnableCachedWrapinfoUpdate:=false`**, so the next `UpdateWrapInfo` **fully recalculates wrap for all 300K lines** (~60–100µs/line). During undo this happens ~3× (two undo-pause paints + `DoCommandResults`) = your 60s; the delete pays one recalc = 6.7s. That's also why wrap-off was always fast.

## Fix (v3, keeps v2 + adds the wrap layer)

-   **Incremental wrap update**: structural line ops are recorded; deleted lines' wrap items are removed with one memory-move, surviving items get index-shifted; new lines' wrap is calculated individually and spliced in. No full recalc.
-   **Undo restore cache**: deleted lines' wrap items are cached with 64-bit text hashes; undo restores them (hash-verified) — zero wrap calculation for the restored block.
-   Pause-events are suppressed during bulk runs (the author's "zero handlers" idea — his advice is good but alone insufficient: even one post-bulk full recalc costs 6–19s).

full ai details:
[README.md](https://github.com/user-attachments/files/31844411/README.md)

_________________
related: 
https://github.com/Alexey-T/CudaText/issues/6443
https://github.com/Alexey-T/ATSynEdit/issues/368