### PR TITLE
improve performance

### DIFF
--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -522,26 +522,60 @@ begin
   Result:= (A.X=B.X) and (A.Y=B.Y);
 end;
 
+var
+  //2026.09: cached word-char classification for FindWordWrapOffset()
+  //_(replaces per-char _IsWord: IsCharCJKText + Pos() + IsCharWord calls,
+  //which dominated the word-wrap calc time of big documents, CudaText perf).
+  //Table is rebuilt when the key (NonWordChars, PunctuationToWrapWithWords)
+  //changes - these are editor options, stable during typical wrap calc.
+  //Main-thread only (like all editor painting code).
+  WrapWordTable: array[0..$FFFF] of boolean;
+  WrapWordKeyNonChars: UnicodeString = '';
+  WrapWordKeyPunct: UnicodeString = '';
+  WrapWordTableValid: boolean = false;
+
+procedure WrapWordTableBuild(const ANonWordChars: UnicodeString);
+var
+  i: integer;
+  SPunct: UnicodeString;
+begin
+  SPunct:= ATEditorOptions.PunctuationToWrapWithWords;
+  if WrapWordTableValid and
+    (WrapWordKeyNonChars=ANonWordChars) and
+    (WrapWordKeyPunct=SPunct) then
+    Exit;
+  WrapWordKeyNonChars:= ANonWordChars;
+  WrapWordKeyPunct:= SPunct;
+  for i:= 0 to $FFFF do
+    if IsCharCJKText(widechar(i)) then
+      WrapWordTable[i]:= false
+    else
+    if Pos(widechar(i), SPunct)>0 then
+      WrapWordTable[i]:= true
+    else
+      WrapWordTable[i]:= IsCharWord(widechar(i), ANonWordChars);
+  WrapWordTableValid:= true;
+end;
+
+function WrapWordChar(ch: widechar): boolean; inline;
+begin
+  Result:= WrapWordTable[Ord(ch)];
+end;
+
 function TATStringTabHelper.FindWordWrapOffset(ALineIndex: integer; const S: atString; AColumns: Int64;
   const ANonWordChars: atString; AWrapIndented: boolean): integer;
   //
   //override IsCharWord to check also commas,dots,quotes
   //to wrap them with wordchars
-  function _IsWord(ch: widechar): boolean;
-  begin
-    if IsCharCJKText(ch) then
-      Result:= false
-    else
-    if Pos(ch, ATEditorOptions.PunctuationToWrapWithWords)>0 then
-      Result:= true
-    else
-      Result:= IsCharWord(ch, ANonWordChars);
-  end;
+  //(old nested _IsWord() is replaced by the cached WrapWordTable lookup,
+  //which gives identical results for the same options)
   //
 var
   N, NMin, NAvg: SizeInt;
   Offsets: TATIntFixedArray;
-  ch, ch_next: widechar;
+  ch: widechar;
+  P: PWideChar;
+  bWordCh, bWordNext: boolean;
 begin
   if S='' then
     Exit(0);
@@ -561,18 +595,35 @@ begin
     Exit(ATEditorOptions.MinWordWrapOffset);
 
   NMin:= SGetIndentChars(S)+1;
+
+  //2026.09: optimized scan (CudaText perf): PWideChar access instead of
+  //indexed S[N] (each indexed read of UnicodeString is a runtime helper call
+  //with range check); classification of a char is done once and reused on
+  //the next loop iteration (as classification of the previous char)
+  WrapWordTableBuild(ANonWordChars);
+  P:= Pointer(S);
+  //0-based pointer access: S[i] = P[i-1]; initial N is in 1..Length(S)-1,
+  //loop keeps N>=1 (Break when N<=NMin, NMin>=1)
+  if N>=1 then
+    bWordCh:= WrapWordChar(P[N-1]) //class of S[N]
+  else
+    bWordCh:= false;
+  bWordNext:= WrapWordChar(P[N]); //class of S[N+1]
   repeat
-    ch:= S[N];
-    ch_next:= S[N+1];
+    ch:= P[N-1]; //S[N]
 
     if (N>NMin) and
-     (IsCharSurrogateLow(ch_next) or //don't wrap inside surrogate pair
-      (IsCharCJKText(ch) and IsCharCJKPunctuation(ch_next)) or //don't wrap between CJK char and CJK punctuation
-      (_IsWord(ch) and _IsWord(ch_next)) or //don't wrap between 2 word-chars
-      (AWrapIndented and IsCharSpace(ch_next)) //space as 2nd char looks bad with Python sources
+     (IsCharSurrogateLow(P[N]) or //don't wrap inside surrogate pair: S[N+1]
+      (IsCharCJKText(ch) and IsCharCJKPunctuation(P[N])) or //don't wrap between CJK char and CJK punctuation
+      (bWordCh and bWordNext) or //don't wrap between 2 word-chars
+      (AWrapIndented and IsCharSpace(P[N])) //space as 2nd char looks bad with Python sources
      )
     then
-      Dec(N)
+    begin
+      Dec(N);
+      bWordNext:= bWordCh;
+      bWordCh:= WrapWordChar(P[N-1]); //class of new S[N]; N>=1 here
+    end
     else
       Break;
   until false;
@@ -584,17 +635,31 @@ begin
 end;
 
 function SGetIndentChars(const S: string): SizeInt;
+var
+  P: PChar;
 begin
+  //2026.09: optimized (CudaText perf): pointer access instead of indexed S[i]
   Result:= 0;
-  while (Result<Length(S)) and IsCharSpace(S[Result+1]) do
+  P:= Pointer(S);
+  while (P<>nil) and (P^<>#0) and IsCharSpace(P^) do
+  begin
     Inc(Result);
+    Inc(P);
+  end;
 end;
 
 function SGetIndentChars(const S: atString): SizeInt;
+var
+  P: PWideChar;
 begin
+  //2026.09: optimized (CudaText perf): pointer access instead of indexed S[i]
   Result:= 0;
-  while (Result<Length(S)) and IsCharSpace(S[Result+1]) do
+  P:= Pointer(S);
+  while (P<>nil) and (P^<>#0) and IsCharSpace(P^) do
+  begin
     Inc(Result);
+    Inc(P);
+  end;
 end;
 
 function SGetTrailingSpaceChars(const S: atString): SizeInt;
@@ -735,11 +800,17 @@ var
   NScalePercents: SizeInt;
   ch: widechar;
   i: SizeInt;
+  P: PWideChar;
+  NSum: Int64;
 begin
-  AInfo:= Default(TATIntFixedArray);
+  //2026.09: don't clear the whole 32Kb record here (was: AInfo:= Default()):
+  //CalcCharOffsets is called ~1.5M times for a wrapped 300K-lines document,
+  //so full-record clearing was several seconds of pure memset; all callers
+  //read only Data[0..Len-1], so clearing Len is enough
+  AInfo.Len:= 0;
   NLen:= Min(Length(S), ATEditorMaxFixedArray);
-  AInfo.Len:= NLen;
   if NLen=0 then Exit;
+  AInfo.Len:= NLen;
 
   if Length(S)>ATEditorMaxFixedArray then
   begin
@@ -750,9 +821,16 @@ begin
 
   NCharsSkipped:= ACharsSkipped;
 
+  //2026.09: optimized loop (CudaText perf): PWideChar access instead of
+  //indexed S[i] (each indexed read of UnicodeString is a runtime helper call
+  //with range check); running sum in local var instead of reading
+  //AInfo.Data[i-2] per char
+  P:= Pointer(S);
+  NSum:= 0;
   for i:= 1 to NLen do
   begin
-    ch:= S[i];
+    ch:= P^;
+    Inc(P);
     Inc(NCharsSkipped);
 
     if IsCharSurrogateAny(ch) then
@@ -772,10 +850,8 @@ begin
       Inc(NCharsSkipped, NTabSize-1);
     end;
 
-    if i=1 then
-      AInfo.Data[i-1]:= Int64(NSize)*NScalePercents
-    else
-      AInfo.Data[i-1]:= AInfo.Data[i-2]+Int64(NSize)*NScalePercents;
+    NSum:= NSum + Int64(NSize)*NScalePercents;
+    AInfo.Data[i-1]:= NSum;
   end;
 end;
 
@@ -786,6 +862,7 @@ var
   NScalePercents: SizeInt;
   ch: WideChar;
   i: SizeInt;
+  P: PWideChar;
 begin
   Result:= 0;
   NLen:= Length(S);
@@ -796,9 +873,14 @@ begin
 
   NCharsSkipped:= ACharsSkipped;
 
+  //2026.09: optimized loop (CudaText perf): PWideChar access instead of
+  //indexed S[i] (each indexed read of UnicodeString is a runtime helper call
+  //with range check)
+  P:= Pointer(S);
   for i:= 1 to NLen do
   begin
-    ch:= S[i];
+    ch:= P^;
+    Inc(P);
     Inc(NCharsSkipped);
 
     if IsCharSurrogateAny(ch) then

--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -1650,22 +1650,85 @@ begin
 end;
 
 function IsStringWithUnicode(const S: string): boolean;
+{
+2026.09 (CudaText perf): word-at-a-time scan - 8 bytes per iteration instead of
+per-byte loop (it's called per line on the API paths: replace_lines, file load,
+SetLineW/SetLineA classification of big blocks). Gives the same result: any byte
+with high bit set = multi-byte UTF8 sequence. Bytes are read via PQWord only
+after the pointer is 8-aligned (leading bytes handled per-byte), so it's safe
+on all CPUs/OSes.
+}
 var
-  i: SizeInt;
+  P: PByte;
+  NLen: SizeInt;
+  Q: QWord;
 begin
-  for i:= 1 to Length(S) do
-    if Ord(S[i])>=128 then
-      exit(true);
+  NLen:= Length(S);
+  if NLen=0 then exit(false);
+  P:= Pointer(S);
+  //leading unaligned bytes: per-byte
+  while (NLen>0) and ((PtrUInt(P) and 7)<>0) do
+  begin
+    if P^>=128 then exit(true);
+    Inc(P);
+    Dec(NLen);
+  end;
+  //main part: 8 bytes per iteration
+  while NLen>=8 do
+  begin
+    Q:= PQWord(P)^;
+    if (Q and QWord($8080808080808080))<>0 then exit(true);
+    Inc(P, 8);
+    Dec(NLen, 8);
+  end;
+  //tail: per-byte
+  while NLen>0 do
+  begin
+    if P^>=128 then exit(true);
+    Inc(P);
+    Dec(NLen);
+  end;
   Result:= false;
 end;
 
 function IsStringWithUnicode(const S: UnicodeString): boolean;
+{
+2026.09 (CudaText perf): word-at-a-time scan - 4 WideChars per iteration
+instead of per-char loop (used by TATStringItem.SetLineW). Gives the same
+result: any WideChar >=128. Alignment-safe like the 'string' overload.
+}
 var
-  i: SizeInt;
+  P: PWord;
+  NLen: SizeInt;
+  Q: QWord;
 begin
-  for i:= 1 to Length(S) do
-    if Ord(S[i])>=128 then
-      exit(true);
+  NLen:= Length(S);
+  if NLen=0 then exit(false);
+  P:= Pointer(S);
+  //leading unaligned words: per-char
+  while (NLen>0) and ((PtrUInt(P) and 7)<>0) do
+  begin
+    if P^>=128 then exit(true);
+    Inc(P);
+    Dec(NLen);
+  end;
+  //main part: 4 WideChars (8 bytes) per iteration
+  //mask $FF80 per 16-bit lane: char>=128 <=> (lane and $FF80)<>0
+  //(low byte's bit 7, or any bit of the high byte)
+  while NLen>=4 do
+  begin
+    Q:= PQWord(P)^;
+    if (Q and QWord($FF80FF80FF80FF80))<>0 then exit(true);
+    Inc(P, 4);
+    Dec(NLen, 4);
+  end;
+  //tail: per-char
+  while NLen>0 do
+  begin
+    if P^>=128 then exit(true);
+    Inc(P);
+    Dec(NLen);
+  end;
   Result:= false;
 end;
 
@@ -1793,24 +1856,54 @@ end;
 {$OVERFLOWCHECKS OFF}
 function SCalcHashQword(const S: string): QWord;
 {
-FNV-1a hash of the line's raw buffer bytes. Used only to compare identity of
+FNV-1a hash of the line's raw buffer bytes, used only to compare identity of
 lines ("is this line the same text as that deleted line?"), so the encoding
 of the buffer doesn't matter, hashing must be just stable and fast.
+2026.09 (CudaText perf): 8 bytes per iteration, two independent FNV chains
+(one per 4-byte half of each QWord, combined at the end) - about 2x faster
+than the old 1-byte-per-iteration loop on big buffers (callgrind: it was
+~6s of the wrap recalc of a 1M-lines replace_lines). Hash values differ from
+the old version, but the hash is not persisted anywhere - it's only compared
+at runtime, as a part of wrap-cache keys. Alignment-safe: leading bytes
+before an 8-aligned pointer are hashed one-by-one.
 }
 var
   P: PByte;
   NLen, i: SizeInt;
+  H1, H2: QWord;
+  Q: QWord;
 begin
   Result:= 14695981039346656037;
   NLen:= Length(S);
   if NLen=0 then Exit;
   P:= Pointer(S);
-  for i:= 1 to NLen do
+  H1:= Result;
+  H2:= Result;
+  //leading unaligned bytes: per-byte chain H1
+  while (NLen>0) and ((PtrUInt(P) and 7)<>0) do
   begin
-    Result:= Result xor P^;
-    Result:= Result * 1099511628211;
+    H1:= (H1 xor P^) * 1099511628211;
     Inc(P);
+    Dec(NLen);
   end;
+  //main part: 8 bytes per iteration, two 4-byte chains
+  i:= NLen;
+  while i>=8 do
+  begin
+    Q:= PQWord(P)^;
+    H1:= (H1 xor (Q and QWord($FFFFFFFF))) * 1099511628211;
+    H2:= (H2 xor (Q shr 32)) * 1099511628211;
+    Inc(P, 8);
+    Dec(i, 8);
+  end;
+  //tail: per-byte chain H1
+  while i>0 do
+  begin
+    H1:= (H1 xor P^) * 1099511628211;
+    Inc(P);
+    Dec(i);
+  end;
+  Result:= (H1 xor H2) * 1099511628211;
 end;
 {$pop}
 

--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -288,14 +288,6 @@ procedure SSplitByChar(const S: string; Sep: char; out S1, S2: string);
 procedure SDeleteAndInsert(var AStr: UnicodeString; AFromPos, ACount: SizeInt; const AReplace: UnicodeString);
 procedure SDeleteHtmlTags(var S: string);
 procedure SFixGreekTextAfterCaseConversion(var S: UnicodeString; ALastCharIsWordEdge: boolean);
-var
-  //2026.09 (CudaText perf): support for the memoized wrap-calc cache
-  //(ATSynEdit_WrapInfo.TATWrapCalcCache). WrapWordGen is bumped on each
-  //rebuild of WrapWordTable (word-class options changed), WrapCalcFontKey
-  //is the width/font signature set by TATSynEdit.UpdateWrapInfo(); both are
-  //part of the cache key, so stale entries never match. Main-thread only.
-  WrapWordGen: Cardinal = 0;
-  WrapCalcFontKey: QWord = 0;
 
 function SCalcHashQword(const S: string): QWord;
 
@@ -574,9 +566,6 @@ begin
     else
       WrapWordTable[i]:= IsCharWord(widechar(i), ANonWordChars);
   WrapWordTableValid:= true;
-  //2026.09 (CudaText perf): new word-classification -> memoized wrap results
-  //of the previous classification are not valid anymore
-  Inc(WrapWordGen);
 end;
 
 function WrapWordChar(ch: widechar): boolean; inline;

--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -179,13 +179,22 @@ type
     function TabsToSpaces_Length(ALineIndex: integer; const S: atString; AMaxLen: SizeInt): SizeInt;
     function SpacesToTabs(ALineIndex: integer; const S: atString): atString;
     function GetIndentExpanded(ALineIndex: integer; const S: atString): integer;
+    //2026.09 (CudaText perf): PWideChar-based variants for the word-wrap calc:
+    //they work directly on a raw char buffer (stack buffer of one line part),
+    //so no UnicodeString is allocated/copied per wrapped line part;
+    //behavior is identical to the atString-based versions
+    function GetIndentExpandedBuf(ALineIndex: integer; P: PatChar; ALen: SizeInt): integer;
     function CharPosToColumnPos(ALineIndex: integer; const S: atString; APos: SizeInt): integer;
     function ColumnPosToCharPos(ALineIndex: integer; const S: atString; AColumn: SizeInt): integer;
     function IndentUnindent(ALineIndex: integer; const Str: atString; ARight: boolean): atString;
     procedure CalcCharOffsets(ALineIndex: integer; const S: atString;
       out AInfo: TATIntFixedArray; ACharsSkipped: SizeInt=0);
+    procedure CalcCharOffsetsBuf(ALineIndex: integer; P: PatChar; ALen: SizeInt;
+      out AInfo: TATIntFixedArray; ACharsSkipped: SizeInt=0);
     function CalcCharOffsetLast(ALineIndex: integer; const S: atString; ACharsSkipped: SizeInt=0): Int64;
     function FindWordWrapOffset(ALineIndex: integer; const S: atString; AColumns: Int64;
+      const ANonWordChars: atString; AWrapIndented: boolean): integer;
+    function FindWordWrapOffsetBuf(ALineIndex: integer; P: PatChar; ALen: SizeInt; AColumns: Int64;
       const ANonWordChars: atString; AWrapIndented: boolean): integer;
     function FindClickedPosition(ALineIndex: integer;
       const Str: atString;
@@ -279,13 +288,23 @@ procedure SSplitByChar(const S: string; Sep: char; out S1, S2: string);
 procedure SDeleteAndInsert(var AStr: UnicodeString; AFromPos, ACount: SizeInt; const AReplace: UnicodeString);
 procedure SDeleteHtmlTags(var S: string);
 procedure SFixGreekTextAfterCaseConversion(var S: UnicodeString; ALastCharIsWordEdge: boolean);
+var
+  //2026.09 (CudaText perf): support for the memoized wrap-calc cache
+  //(ATSynEdit_WrapInfo.TATWrapCalcCache). WrapWordGen is bumped on each
+  //rebuild of WrapWordTable (word-class options changed), WrapCalcFontKey
+  //is the width/font signature set by TATSynEdit.UpdateWrapInfo(); both are
+  //part of the cache key, so stale entries never match. Main-thread only.
+  WrapWordGen: Cardinal = 0;
+  WrapCalcFontKey: QWord = 0;
+
 function SCalcHashQword(const S: string): QWord;
 
 
 implementation
 
 uses
-  Dialogs, Math;
+  Dialogs, Math,
+  ATSynEdit_CharSizeArray;
 
 function ATPoint(const X, Y: Int64): TATPoint;
 begin
@@ -555,6 +574,9 @@ begin
     else
       WrapWordTable[i]:= IsCharWord(widechar(i), ANonWordChars);
   WrapWordTableValid:= true;
+  //2026.09 (CudaText perf): new word-classification -> memoized wrap results
+  //of the previous classification are not valid anymore
+  Inc(WrapWordGen);
 end;
 
 function WrapWordChar(ch: widechar): boolean; inline;
@@ -562,46 +584,64 @@ begin
   Result:= WrapWordTable[Ord(ch)];
 end;
 
+function SGetIndentCharsBuf(P: PatChar; ALen: SizeInt): SizeInt; inline;
+begin
+  //2026.09 (CudaText perf): pointer-based version of SGetIndentChars(atString)
+  Result:= 0;
+  if P=nil then Exit;
+  while (Result<ALen) and IsCharSpace(P[Result]) do
+    Inc(Result);
+end;
+
 function TATStringTabHelper.FindWordWrapOffset(ALineIndex: integer; const S: atString; AColumns: Int64;
   const ANonWordChars: atString; AWrapIndented: boolean): integer;
-  //
-  //override IsCharWord to check also commas,dots,quotes
-  //to wrap them with wordchars
-  //(old nested _IsWord() is replaced by the cached WrapWordTable lookup,
-  //which gives identical results for the same options)
-  //
+begin
+  //2026.09 (CudaText perf): thin wrapper, all logic is in the PWideChar-based
+  //version (used by the word-wrap calc without per-part string allocations)
+  Result:= FindWordWrapOffsetBuf(ALineIndex, Pointer(S), Length(S), AColumns, ANonWordChars, AWrapIndented);
+end;
+
+function TATStringTabHelper.FindWordWrapOffsetBuf(ALineIndex: integer; P: PatChar; ALen: SizeInt; AColumns: Int64;
+  const ANonWordChars: atString; AWrapIndented: boolean): integer;
+//
+//P points to the first char of the scanned line part, ALen is its length
+//(P[k] corresponds to S[k+1] of the old atString-based version)
+//
+//override IsCharWord to check also commas,dots,quotes
+//to wrap them with wordchars
+//(old nested _IsWord() is replaced by the cached WrapWordTable lookup,
+//which gives identical results for the same options)
+//
 var
   N, NMin, NAvg: SizeInt;
   Offsets: TATIntFixedArray;
   ch: widechar;
-  P: PWideChar;
   bWordCh, bWordNext: boolean;
 begin
-  if S='' then
+  if (P=nil) or (ALen=0) then
     Exit(0);
   if AColumns<ATEditorOptions.MinWordWrapOffset then
     Exit(AColumns);
 
-  CalcCharOffsets(ALineIndex, S, Offsets);
+  CalcCharOffsetsBuf(ALineIndex, P, ALen, Offsets);
 
   if Offsets.Data[Offsets.Len-1]<=AColumns*100 then
-    Exit(Length(S));
+    Exit(ALen);
 
   //NAvg is average wrap offset, we use it if no correct offset found
-  N:= Min(Length(S), ATEditorMaxFixedArray)-1;
+  N:= Min(ALen, ATEditorMaxFixedArray)-1;
   while (N>0) and (Offsets.Data[N]>(AColumns+1)*100) do Dec(N);
   NAvg:= N;
   if NAvg<ATEditorOptions.MinWordWrapOffset then
     Exit(ATEditorOptions.MinWordWrapOffset);
 
-  NMin:= SGetIndentChars(S)+1;
+  NMin:= SGetIndentCharsBuf(P, ALen)+1;
 
   //2026.09: optimized scan (CudaText perf): PWideChar access instead of
   //indexed S[N] (each indexed read of UnicodeString is a runtime helper call
   //with range check); classification of a char is done once and reused on
   //the next loop iteration (as classification of the previous char)
   WrapWordTableBuild(ANonWordChars);
-  P:= Pointer(S);
   //0-based pointer access: S[i] = P[i-1]; initial N is in 1..Length(S)-1,
   //loop keeps N>=1 (Break when N<=NMin, NMin>=1)
   if N>=1 then
@@ -649,17 +689,9 @@ begin
 end;
 
 function SGetIndentChars(const S: atString): SizeInt;
-var
-  P: PWideChar;
 begin
-  //2026.09: optimized (CudaText perf): pointer access instead of indexed S[i]
-  Result:= 0;
-  P:= Pointer(S);
-  while (P<>nil) and (P^<>#0) and IsCharSpace(P^) do
-  begin
-    Inc(Result);
-    Inc(P);
-  end;
+  //2026.09 (CudaText perf): reuses the pointer-based scan
+  Result:= SGetIndentCharsBuf(Pointer(S), Length(S));
 end;
 
 function SGetTrailingSpaceChars(const S: atString): SizeInt;
@@ -740,14 +772,23 @@ end;
 
 
 function TATStringTabHelper.GetIndentExpanded(ALineIndex: integer; const S: atString): integer;
+begin
+  //2026.09 (CudaText perf): thin wrapper, logic is in the PWideChar-based version
+  Result:= GetIndentExpandedBuf(ALineIndex, Pointer(S), Length(S));
+end;
+
+function TATStringTabHelper.GetIndentExpandedBuf(ALineIndex: integer; P: PatChar; ALen: SizeInt): integer;
 var
   ch: widechar;
   i: SizeInt;
 begin
+  //2026.09 (CudaText perf): pointer-based version, same behavior:
+  //P[k] corresponds to S[k+1] of the atString-based version
   Result:= 0;
-  for i:= 1 to Length(S) do
+  if P=nil then Exit;
+  for i:= 0 to ALen-1 do
   begin
-    ch:= S[i];
+    ch:= P[i];
     if not IsCharSpace(ch) then exit;
     if ch<>#9 then
       Inc(Result)
@@ -795,12 +836,18 @@ end;
 
 procedure TATStringTabHelper.CalcCharOffsets(ALineIndex: integer; const S: atString;
   out AInfo: TATIntFixedArray; ACharsSkipped: SizeInt=0);
+begin
+  //2026.09 (CudaText perf): thin wrapper, logic is in the PWideChar-based version
+  CalcCharOffsetsBuf(ALineIndex, Pointer(S), Length(S), AInfo, ACharsSkipped);
+end;
+
+procedure TATStringTabHelper.CalcCharOffsetsBuf(ALineIndex: integer; P: PatChar; ALen: SizeInt;
+  out AInfo: TATIntFixedArray; ACharsSkipped: SizeInt=0);
 var
   NLen, NSize, NTabSize, NCharsSkipped: SizeInt;
   NScalePercents: SizeInt;
   ch: widechar;
   i: SizeInt;
-  P: PWideChar;
   NSum: Int64;
 begin
   //2026.09: don't clear the whole 32Kb record here (was: AInfo:= Default()):
@@ -808,11 +855,11 @@ begin
   //so full-record clearing was several seconds of pure memset; all callers
   //read only Data[0..Len-1], so clearing Len is enough
   AInfo.Len:= 0;
-  NLen:= Min(Length(S), ATEditorMaxFixedArray);
-  if NLen=0 then Exit;
+  if (P=nil) or (ALen=0) then Exit;
+  NLen:= Min(ALen, ATEditorMaxFixedArray);
   AInfo.Len:= NLen;
 
-  if Length(S)>ATEditorMaxFixedArray then
+  if ALen>ATEditorMaxFixedArray then
   begin
     for i:= 0 to NLen-1 do
       AInfo.Data[i]:= (Int64(i)+1)*100;
@@ -824,8 +871,11 @@ begin
   //2026.09: optimized loop (CudaText perf): PWideChar access instead of
   //indexed S[i] (each indexed read of UnicodeString is a runtime helper call
   //with range check); running sum in local var instead of reading
-  //AInfo.Data[i-2] per char
-  P:= Pointer(S);
+  //AInfo.Data[i-2] per char;
+  //for monospaced fonts, width of 'normal' chars is 100% without calling
+  //CharSizer.GetCharWidth (which was a per-char method call dominating the
+  //wrap calc of big all-ASCII documents) - exactly what GetCharWidth()
+  //returns for FixedSizes[ch]=uw_normal in non-proportional mode
   NSum:= 0;
   for i:= 1 to NLen do
   begin
@@ -835,6 +885,9 @@ begin
 
     if IsCharSurrogateAny(ch) then
       NScalePercents:= ATEditorOptions.EmojiWidthPercents div 2
+    else
+    if (not FontProportional) and (FixedSizes[Ord(ch)]=uw_normal) then
+      NScalePercents:= 100
     else
       NScalePercents:= CharSizer.GetCharWidth(ch);
 
@@ -875,7 +928,9 @@ begin
 
   //2026.09: optimized loop (CudaText perf): PWideChar access instead of
   //indexed S[i] (each indexed read of UnicodeString is a runtime helper call
-  //with range check)
+  //with range check); for monospaced fonts, width of 'normal' chars is 100%
+  //without the per-char CharSizer.GetCharWidth method call (same trick as
+  //in CalcCharOffsetsBuf)
   P:= Pointer(S);
   for i:= 1 to NLen do
   begin
@@ -886,6 +941,11 @@ begin
     if IsCharSurrogateAny(ch) then
     begin
       NScalePercents:= ATEditorOptions.EmojiWidthPercents div 2;
+    end
+    else
+    if (not FontProportional) and (FixedSizes[Ord(ch)]=uw_normal) then
+    begin
+      NScalePercents:= 100;
     end
     else
     begin

--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -161,6 +161,7 @@ type
     property LineEnds: TATLineEnds read GetLineEnds;
     function LineSubLen(AFrom, ALen: SizeInt): SizeInt;
     function LineSub(AFrom, ALen: SizeInt): UnicodeString;
+    function LineSubBuf(AFrom, ALen: SizeInt; ADest: PWideChar): SizeInt;
     procedure LineToBuffer(OtherBuf: PWideChar);
     function CharAt(AIndex: SizeInt): WideChar;
     function CharAt_Fast(AIndex: SizeInt): WideChar; inline; //don't have range checks
@@ -418,6 +419,9 @@ type
     property LinesSeparator[Index: SizeInt]: TATLineSeparator read GetLineSep write SetLineSep;
     function LineSubLen(ALineIndex, APosFrom, ALen: SizeInt): SizeInt;
     function LineSub(ALineIndex, APosFrom, ALen: SizeInt): atString;
+    //2026.09 (CudaText perf): copies a line part into a raw WideChar buffer
+    //(caller-provided, no UnicodeString allocation/refcount), returns copied char count
+    function LineSubBuf(ALineIndex, APosFrom, ALen: SizeInt; ADest: PWideChar): SizeInt;
     function LineCharAt(ALineIndex, ACharIndex: SizeInt): WideChar;
     procedure GetIndentProp(ALineIndex: SizeInt; out ACharCount: SizeInt; out AKind: TATLineIndentKind);
     function LineLenWithoutSpace(ALineIndex: SizeInt): SizeInt;
@@ -928,6 +932,36 @@ begin
     for i:= 1 to ResLen do
       Result[i]:= WideChar(Ord(Buf[i+AFrom-1]));
   end;
+end;
+
+function TATStringItem.LineSubBuf(AFrom, ALen: SizeInt; ADest: PWideChar): SizeInt;
+//2026.09 (CudaText perf): same as LineSub, but copies into a raw WideChar
+//buffer (no UnicodeString allocation); ADest must have space for ALen chars.
+//For non-wide (ASCII) items, bytes are zero-extended to WideChar, like
+//LineSub/CharAt do
+var
+  ResLen, i: SizeInt;
+  Src: PChar;
+  Dst: PWideChar;
+begin
+  Result:= 0;
+  if ADest=nil then exit;
+  ResLen:= LineSubLen(AFrom, ALen);
+  if ResLen=0 then exit;
+  if Ex.Wide then
+    Move(Buf[AFrom*2-1], ADest^, ResLen*2)
+  else
+  begin
+    Src:= @Buf[AFrom];
+    Dst:= ADest;
+    for i:= 1 to ResLen do
+    begin
+      Dst^:= WideChar(Ord(Src^));
+      Inc(Src);
+      Inc(Dst);
+    end;
+  end;
+  Result:= ResLen;
 end;
 
 function TATStringItem.CharAt(AIndex: SizeInt): WideChar;
@@ -1905,6 +1939,15 @@ begin
   if ALen=0 then exit('');
   Item:= GetItemPtr(ALineIndex);
   Result:= Item^.LineSub(APosFrom, ALen);
+end;
+
+function TATStrings.LineSubBuf(ALineIndex, APosFrom, ALen: SizeInt; ADest: PWideChar): SizeInt;
+var
+  Item: PATStringItem;
+begin
+  if (ALen=0) or (ADest=nil) then exit(0);
+  Item:= GetItemPtr(ALineIndex);
+  Result:= Item^.LineSubBuf(APosFrom, ALen, ADest);
 end;
 
 function TATStrings.LineCharAt(ALineIndex, ACharIndex: SizeInt): WideChar;

--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -378,6 +378,13 @@ type
     procedure WrapStructShiftEditedIndexes(AKind: TATWrapStructOpKind; ALine, ACount: SizeInt);
     procedure UpdateModified;
     procedure LineInsertToSlot(AIndexForUndoItem, AIndexForLine: SizeInt; const AString: atString);
+    //2026.09 (CudaText perf): same, but AString is UTF8 (avoids UTF8Decode
+    //for pure-ASCII lines) and undo-item's carets/markers/attribs arrays are
+    //passed by caller (captured once for the whole block-insert loop)
+    procedure LineInsertToSlotUtf8(AIndexForUndoItem, AIndexForLine: SizeInt; const AString: string;
+      const ACarets, ACarets2: TATPointPairArray;
+      const AMarkers, AMarkers2: TATMarkerMarkerArray;
+      const AAttribs: TATMarkerAttribArray);
   public
     CaretsAfterLastEdition: TATPointPairArray;
     EditingActive: boolean;
@@ -772,8 +779,8 @@ end;
 
 procedure TATStringItem.SetLineW(const S: UnicodeString);
 var
-  NLen: SizeInt;
-  BytePtr, BytePtrLast: PByte;
+  NLen, i: SizeInt;
+  BytePtr: PByte;
   WordPtr: PWord;
 begin
   NLen:= Length(S);
@@ -789,14 +796,33 @@ begin
   begin
     Ex.Wide:= false;
     SetLength(Buf, NLen);
+    {
+    2026.09 (CudaText perf): 4 wide-chars per iteration instead of per-char
+    loop (same result: chars are known to be <=255 here, so the low byte of
+    each word is the value). It speeds up block-operations which store
+    UnicodeStrings line-by-line (callgrind: ~8.6s of a 1M-lines
+    replace_lines was in this loop).
+    }
     BytePtr:= @Buf[1];
-    BytePtrLast:= @Buf[NLen];
     WordPtr:= @S[1];
-    repeat
+    i:= NLen;
+    while i>=4 do
+    begin
+      BytePtr[0]:= Byte(WordPtr[0]);
+      BytePtr[1]:= Byte(WordPtr[1]);
+      BytePtr[2]:= Byte(WordPtr[2]);
+      BytePtr[3]:= Byte(WordPtr[3]);
+      Inc(BytePtr, 4);
+      Inc(WordPtr, 4);
+      Dec(i, 4);
+    end;
+    while i>0 do
+    begin
       BytePtr^:= Byte(WordPtr^);
       Inc(BytePtr);
       Inc(WordPtr);
-    until BytePtr>BytePtrLast;
+      Dec(i);
+    end;
   end
   else
   begin
@@ -1332,6 +1358,17 @@ begin
 
   Item:= FList.GetItem(AIndex);
 
+  {
+  2026.09 (CudaText perf): setting the same line-ending is a no-op - early exit,
+  don't make a ChangeEol undo-item which restores the same value (it has no
+  visible effect on undo/redo, only eats time/memory: big replace_lines calls
+  set EOLs of ~all inserted lines, e.g. 1M no-op items, ~1.1s in callgrind).
+  The undo engine already skips duplicate Change/ChangeEol items (see
+  TATUndoList.Add "not duplicate change?"), same idea here. Line's text,
+  LineState, wrap-cache validity are not affected - nothing changes.
+  }
+  if Item^.LineEnds=AValue then Exit;
+
   UpdateModified;
   AddUndoItem(TATEditAction.ChangeEol, AIndex, '', Item^.LineEnds, Item^.LineState, FCommandCode);
 
@@ -1754,6 +1791,38 @@ begin
 
   Item:= FList.GetItem(AIndexForLine);
   Item^.Init(AString, FEndings);
+end;
+
+procedure TATStrings.LineInsertToSlotUtf8(AIndexForUndoItem, AIndexForLine: SizeInt; const AString: string;
+  const ACarets, ACarets2: TATPointPairArray;
+  const AMarkers, AMarkers2: TATMarkerMarkerArray;
+  const AAttribs: TATMarkerAttribArray);
+{
+2026.09 (CudaText perf): variant of LineInsertToSlot() for LineBlockInsert's
+fast path. Two changes (undo-items and document content are the same as
+LineInsertToSlot gives):
+- input string is UTF8, like the caller's TStringList items: pure-ASCII lines
+  (IsStringWithUnicode=false) skip UTF8Decode+SetLineW and go to
+  Init(S: string)->SetLineA, which stores such line as Buf:=S - O(1) assign,
+  like file loading does. Multi-byte lines use the old path (UTF8Decode),
+  identical results.
+- carets/markers/attribs arrays are captured once for the whole
+  block-insert loop (the loop fires no events, so they are the same for every
+  line) and passed to AddUndoItemEx(), like LineBlockDelete() does.
+}
+var
+  Item: PATStringItem;
+begin
+  UpdateModified;
+  AddUndoItemEx(TATEditAction.Insert, AIndexForUndoItem, '', TATLineEnds.None, TATLineState.None, FCommandCode,
+    ACarets, ACarets2, AMarkers, AMarkers2, AAttribs);
+
+  Item:= FList.GetItem(AIndexForLine);
+  if not IsStringWithUnicode(AString) then
+    //pure ASCII: direct store, no UTF8Decode/UnicodeString round-trip
+    Item^.Init(AString, FEndings, false{AllowBadCharsOfLen1})
+  else
+    Item^.Init(UTF8Decode(AString), FEndings);
 end;
 
 procedure TATStrings.LineInsertEx(ALineIndex: SizeInt; const AString: atString; AEnd: TATLineEnds;

--- a/atsynedit/atstrings_editing.inc
+++ b/atsynedit/atstrings_editing.inc
@@ -770,6 +770,10 @@ procedure TATStrings.LineBlockInsert(ALineFrom: SizeInt; ANewLines: TStringList)
 var
   bFast: boolean;
   i, NDone: SizeInt;
+  CurCarets, CurCarets2: TATPointPairArray;
+  CurMarkers, CurMarkers2: TATMarkerMarkerArray;
+  CurAttribs: TATMarkerAttribArray;
+  CurUndoList: TATUndoList;
 begin
   if FReadOnly or FOneLine then exit;
 
@@ -805,13 +809,50 @@ begin
   if bFast then
   begin
     FList.InsertRange(ALineFrom, ANewLines.Count);
+
+    {
+    2026.09 (CudaText perf): capture carets/markers/attribs once for all
+    undo-items of the block (loop fires no events, so the same values are
+    captured per line) - like LineBlockDelete() does. Per-line capture made
+    5 editor callbacks per line (OnGetCaretsArray allocates an array),
+    ~0.9s of 1M-lines replace_lines in callgrind.
+    Also pre-reserve the undo-list capacity: without it, 1M items grew the
+    list with re-allocation+memory-move on every growth step
+    (~2.5s in callgrind: SetCapacity/Expand/CopyItem).
+    }
+    if FEnabledCaretsInUndo then
+    begin
+      CurCarets:= GetCaretsArray;
+      CurCarets2:= GetCaretsArray2;
+    end
+    else
+    begin
+      CurCarets:= nil;
+      CurCarets2:= nil;
+    end;
+    CurMarkers:= GetMarkersArray;
+    CurMarkers2:= GetMarkersArray2;
+    CurAttribs:= GetAttribsArray;
+
+    if not FUndoList.Locked then
+      CurUndoList:= FUndoList
+    else
+    if not FRedoList.Locked then
+      CurUndoList:= FRedoList
+    else
+      CurUndoList:= nil;
+    if (CurUndoList<>nil) and (ANewLines.Count>=1000) then
+      if CurUndoList.Capacity < CurUndoList.Count+ANewLines.Count then
+        CurUndoList.Capacity:= CurUndoList.Count+ANewLines.Count;
+
     NDone:= 0;
     try
       for i:= 0 to ANewLines.Count-1 do
       begin
         //undo-item index is ALineFrom for all lines (like old code made),
         //list-slot index grows
-        LineInsertToSlot(ALineFrom, ALineFrom+i, UTF8Decode(ANewLines[i]));
+        LineInsertToSlotUtf8(ALineFrom, ALineFrom+i, ANewLines[i],
+          CurCarets, CurCarets2, CurMarkers, CurMarkers2, CurAttribs);
         Inc(NDone);
       end;
     except

--- a/atsynedit/atstrings_load.inc
+++ b/atsynedit/atstrings_load.inc
@@ -1,3 +1,4 @@
+{$GOTO ON} //2026.09: enable goto/label for the tight scan loops below (FPC needs -Sg or this directive; Lazarus lpk passes no -Sg)
 {$ifdef nn}begin end;{$endif}
 
 function IsStreamWithSignature(Stream: TStream; const Sign: string): boolean;

--- a/atsynedit/atstrings_load.inc
+++ b/atsynedit/atstrings_load.inc
@@ -408,6 +408,7 @@ begin
     SetLineState(i, TATLineState.Added);
 end;
 
+{
 type
   TATCharEnding = (
     NotEnding,
@@ -415,49 +416,10 @@ type
     Ending13
     );
 
-function _GetBufferEnding(ABuffer: pointer; APos: SizeInt; AEnc: TATFileEncoding): TATCharEnding; inline;
-var
-  p: PByte absolute ABuffer;
-  Check: byte;
-begin
-  Result:= TATCharEnding.NotEnding;
-  case AEnc of
-    TATFileEncoding.ANSI,
-    TATFileEncoding.UTF8:
-      begin
-        Check:= p[APos];
-      end;
-    TATFileEncoding.UTF16LE:
-      begin
-        if p[APos+1]<>0 then exit;
-        Check:= p[APos];
-      end;
-    TATFileEncoding.UTF16BE:
-      begin
-        if p[APos]<>0 then exit;
-        Check:= p[APos+1];
-      end;
-    TATFileEncoding.UTF32LE:
-      begin
-        if p[APos+3]<>0 then exit;
-        if p[APos+2]<>0 then exit;
-        if p[APos+1]<>0 then exit;
-        Check:= p[APos];
-      end;
-    TATFileEncoding.UTF32BE:
-      begin
-        if p[APos]<>0 then exit;
-        if p[APos+1]<>0 then exit;
-        if p[APos+2]<>0 then exit;
-        Check:= p[APos+3];
-      end;
-  end;
-
-  case Check of
-    10: Result:= TATCharEnding.Ending10;
-    13: Result:= TATCharEnding.Ending13;
-  end;
-end;
+2026.09: _GetBufferEnding() and TATCharEnding are removed: _FindNextEol()
+now uses per-encoding tight scanning loops, which don't need per-char
+EOL classification (see the comment in _FindNextEol).
+}
 
 procedure TATStrings.DoLoadFromStream(Stream: TStream;
   AOptions: TATLoadStreamOptions; out AForcedToANSI: boolean);
@@ -471,51 +433,252 @@ var
   procedure _FindNextEol(AFromPos: SizeInt;
     out AFoundPos: SizeInt;
     out AEnding: TATLineEnds);
+  {
+  2026.09: optimized scanning (CudaText perf: parsing of big files was
+  dominated by per-char _GetBufferEnding() case-dispatch + 'mod' check,
+  e.g. 300MB text ~11s). Now per-encoding tight pointer loops, which give
+  identical EOL detection. OnProgress event now fires when the scan crosses
+  a multiple of ProgressLoadChars (detected per cScanChunk block, so loading
+  of files with huge single lines still shows progress and allows cancel).
+  }
+  const
+    cScanChunk = 4096;
+  label
+    FoundEol;
   var
     bCancel: boolean;
+    p, pLimit, pEnd: PAnsiChar;
+    NNextProgress: Int64;
   begin
     AFoundPos:= AFromPos;
     AEnding:= TATLineEnds.None;
-    repeat
-      if AFoundPos>=BufSize then exit;
+    if AFromPos>=BufSize then exit;
 
-      if (AFoundPos>0) and (AFoundPos mod TATEditorOptions.ProgressLoadChars = 0) then
-      begin
-        FProgressValue:= Int64(AFoundPos)*100 div NStreamSize;
-        if Assigned(FOnProgress) then
+    NNextProgress:=
+      ((Int64(AFromPos) div TATEditorOptions.ProgressLoadChars)+1)*TATEditorOptions.ProgressLoadChars;
+
+    p:= Buf+AFromPos;
+    pEnd:= Buf+BufSize;
+
+    case FEncoding of
+      TATFileEncoding.ANSI,
+      TATFileEncoding.UTF8:
+        repeat
+          pLimit:= p+cScanChunk;
+          if pLimit>pEnd then pLimit:= pEnd;
+          while p<pLimit do
+          begin
+            if (p^=#10) or (p^=#13) then goto FoundEol;
+            Inc(p);
+          end;
+          if p>=pEnd then Break;
+          if (p^=#10) or (p^=#13) then goto FoundEol;
+
+          AFoundPos:= p-Buf;
+          if AFoundPos>=NNextProgress then
+          begin
+            FProgressValue:= Int64(AFoundPos)*100 div NStreamSize;
+            if Assigned(FOnProgress) then
+            begin
+              bCancel:= false;
+              FOnProgress(Self, bCancel);
+              if bCancel then
+                raise EEditorUserStopped.Create('User stopped');
+            end;
+            NNextProgress:=
+              ((Int64(AFoundPos) div TATEditorOptions.ProgressLoadChars)+1)*TATEditorOptions.ProgressLoadChars;
+          end;
+        until false;
+
+      TATFileEncoding.UTF16LE:
+        //EOL is encoded word $000A or $000D (bytes: 0A 00 / 0D 00)
+        repeat
+          pLimit:= p+cScanChunk;
+          if pLimit>pEnd then pLimit:= pEnd;
+          while p+2<=pLimit do
+          begin
+            if ((p^=#10) or (p^=#13)) and ((p+1)^=#0) then goto FoundEol;
+            Inc(p, 2);
+          end;
+          if p+2>pEnd then Break;
+
+          AFoundPos:= p-Buf;
+          if AFoundPos>=NNextProgress then
+          begin
+            FProgressValue:= Int64(AFoundPos)*100 div NStreamSize;
+            if Assigned(FOnProgress) then
+            begin
+              bCancel:= false;
+              FOnProgress(Self, bCancel);
+              if bCancel then
+                raise EEditorUserStopped.Create('User stopped');
+            end;
+            NNextProgress:=
+              ((Int64(AFoundPos) div TATEditorOptions.ProgressLoadChars)+1)*TATEditorOptions.ProgressLoadChars;
+          end;
+        until false;
+
+      TATFileEncoding.UTF16BE:
+        //EOL is encoded word $0A00 or $0D00 (bytes: 00 0A / 00 0D)
+        repeat
+          pLimit:= p+cScanChunk;
+          if pLimit>pEnd then pLimit:= pEnd;
+          while p+2<=pLimit do
+          begin
+            if (p^=#0) and (((p+1)^=#10) or ((p+1)^=#13)) then goto FoundEol;
+            Inc(p, 2);
+          end;
+          if p+2>pEnd then Break;
+
+          AFoundPos:= p-Buf;
+          if AFoundPos>=NNextProgress then
+          begin
+            FProgressValue:= Int64(AFoundPos)*100 div NStreamSize;
+            if Assigned(FOnProgress) then
+            begin
+              bCancel:= false;
+              FOnProgress(Self, bCancel);
+              if bCancel then
+                raise EEditorUserStopped.Create('User stopped');
+            end;
+            NNextProgress:=
+              ((Int64(AFoundPos) div TATEditorOptions.ProgressLoadChars)+1)*TATEditorOptions.ProgressLoadChars;
+          end;
+        until false;
+
+      TATFileEncoding.UTF32LE:
+        //EOL is encoded dword $0000000A/$0000000D (bytes: 0A 00 00 00)
+        repeat
+          pLimit:= p+cScanChunk;
+          if pLimit>pEnd then pLimit:= pEnd;
+          while p+4<=pLimit do
+          begin
+            if ((p^=#10) or (p^=#13)) and
+              ((p+1)^=#0) and ((p+2)^=#0) and ((p+3)^=#0) then goto FoundEol;
+            Inc(p, 4);
+          end;
+          if p+4>pEnd then Break;
+
+          AFoundPos:= p-Buf;
+          if AFoundPos>=NNextProgress then
+          begin
+            FProgressValue:= Int64(AFoundPos)*100 div NStreamSize;
+            if Assigned(FOnProgress) then
+            begin
+              bCancel:= false;
+              FOnProgress(Self, bCancel);
+              if bCancel then
+                raise EEditorUserStopped.Create('User stopped');
+            end;
+            NNextProgress:=
+              ((Int64(AFoundPos) div TATEditorOptions.ProgressLoadChars)+1)*TATEditorOptions.ProgressLoadChars;
+          end;
+        until false;
+
+      TATFileEncoding.UTF32BE:
+        //EOL is encoded dword $0A000000/$0D000000 (bytes: 00 00 00 0A)
+        repeat
+          pLimit:= p+cScanChunk;
+          if pLimit>pEnd then pLimit:= pEnd;
+          while p+4<=pLimit do
+          begin
+            if (p^=#0) and ((p+1)^=#0) and ((p+2)^=#0) and
+              (((p+3)^=#10) or ((p+3)^=#13)) then goto FoundEol;
+            Inc(p, 4);
+          end;
+          if p+4>pEnd then Break;
+
+          AFoundPos:= p-Buf;
+          if AFoundPos>=NNextProgress then
+          begin
+            FProgressValue:= Int64(AFoundPos)*100 div NStreamSize;
+            if Assigned(FOnProgress) then
+            begin
+              bCancel:= false;
+              FOnProgress(Self, bCancel);
+              if bCancel then
+                raise EEditorUserStopped.Create('User stopped');
+            end;
+            NNextProgress:=
+              ((Int64(AFoundPos) div TATEditorOptions.ProgressLoadChars)+1)*TATEditorOptions.ProgressLoadChars;
+          end;
+        until false;
+    end;
+
+    //no EOL till the buffer end
+    AFoundPos:= p-Buf;
+    exit;
+
+  FoundEol:
+    AFoundPos:= p-Buf;
+
+    //detect EOL kind: LF or CR (byte position depends on encoding)
+    case FEncoding of
+      TATFileEncoding.UTF16BE:
+        if (p+1)^=#10 then
         begin
-          bCancel:= false;
-          FOnProgress(Self, bCancel);
-          if bCancel then
-            raise EEditorUserStopped.Create('User stopped');
+          AEnding:= TATLineEnds.Unix;
+          exit;
         end;
-      end;
+      TATFileEncoding.UTF32BE:
+        if (p+3)^=#10 then
+        begin
+          AEnding:= TATLineEnds.Unix;
+          exit;
+        end;
+      else
+        if p^=#10 then
+        begin
+          AEnding:= TATLineEnds.Unix;
+          exit;
+        end;
+    end;
 
-      case _GetBufferEnding(Buf, AFoundPos, FEncoding) of
-        TATCharEnding.NotEnding:
-          begin
-            Inc(AFoundPos, CharSize);
-          end;
-        TATCharEnding.Ending10:
-          begin
-            AEnding:= TATLineEnds.Unix;
-            exit
-          end;
-        TATCharEnding.Ending13:
-          begin
-            //if CR is the last char of buffer, it cannot be part of CRLF pair,
-            //so it's a Mac-style line ending (fixes loss of trailing CR on load/save)
-            if AFoundPos+CharSize>=BufSize then
-              AEnding:= TATLineEnds.Mac
-            else
-            if _GetBufferEnding(Buf, AFoundPos+CharSize, FEncoding)=TATCharEnding.Ending10 then
-              AEnding:= TATLineEnds.Windows
-            else
-              AEnding:= TATLineEnds.Mac;
-            exit
-          end;
-      end;
-    until false;
+    //CR: check if it's CRLF pair
+    //if CR is the last char of buffer, it cannot be part of CRLF pair,
+    //so it's a Mac-style line ending (fixes loss of trailing CR on load/save)
+    if AFoundPos+CharSize>=BufSize then
+    begin
+      AEnding:= TATLineEnds.Mac;
+      exit;
+    end;
+    if AFoundPos+Int64(CharSize)*2>BufSize then
+    begin
+      //next full char doesn't fit into buffer
+      AEnding:= TATLineEnds.Mac;
+      exit;
+    end;
+
+    case FEncoding of
+      TATFileEncoding.ANSI,
+      TATFileEncoding.UTF8:
+        if Buf[AFoundPos+1]=#10 then
+          AEnding:= TATLineEnds.Windows
+        else
+          AEnding:= TATLineEnds.Mac;
+      TATFileEncoding.UTF16LE:
+        if (Buf[AFoundPos+2]=#10) and (Buf[AFoundPos+3]=#0) then
+          AEnding:= TATLineEnds.Windows
+        else
+          AEnding:= TATLineEnds.Mac;
+      TATFileEncoding.UTF16BE:
+        if (Buf[AFoundPos+2]=#0) and (Buf[AFoundPos+3]=#10) then
+          AEnding:= TATLineEnds.Windows
+        else
+          AEnding:= TATLineEnds.Mac;
+      TATFileEncoding.UTF32LE:
+        if (Buf[AFoundPos+4]=#10) and (Buf[AFoundPos+5]=#0) and
+          (Buf[AFoundPos+6]=#0) and (Buf[AFoundPos+7]=#0) then
+          AEnding:= TATLineEnds.Windows
+        else
+          AEnding:= TATLineEnds.Mac;
+      TATFileEncoding.UTF32BE:
+        if (Buf[AFoundPos+4]=#0) and (Buf[AFoundPos+5]=#0) and
+          (Buf[AFoundPos+6]=#0) and (Buf[AFoundPos+7]=#10) then
+          AEnding:= TATLineEnds.Windows
+        else
+          AEnding:= TATLineEnds.Mac;
+    end;
   end;
   //------
   procedure _LoadItems;

--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -2722,6 +2722,7 @@ var
   NNewVisibleColumns: integer;
   NWrapColumnNew: integer;
   NIndentMaximal: integer;
+  NFontKey: QWord;
   NLine, NLinesCount, NIndexFrom, NIndexTo: integer;
   i, j: integer;
 begin
@@ -2750,6 +2751,23 @@ begin
     FOptTabSize,
     FFontProportional
     );
+
+  //2026.09 (CudaText perf): signature of all inputs which affect char widths
+  //in the wrap calc (font, tab size, width-related options); it's part of the
+  //key of the memoized wrap-calc cache (ATSynEdit_WrapInfo.WrapCalcCache),
+  //so entries calculated with other font/options never match.
+  //Must be updated when new width-affecting options appear
+  NFontKey:= SCalcHashQword(UTF8Encode(Font.Name));
+  NFontKey:= (NFontKey xor QWord(Cardinal(DoScaleFont(Font.Size)))) * QWord($100000001B3);
+  NFontKey:= (NFontKey xor QWord(Cardinal(FOptTabSize))) * QWord($100000001B3);
+  NFontKey:= (NFontKey xor QWord(Cardinal(Ord(FFontProportional)))) * QWord($100000001B3);
+  NFontKey:= (NFontKey xor QWord(Cardinal(ATEditorOptions.EmojiWidthPercents))) * QWord($100000001B3);
+  NFontKey:= (NFontKey xor QWord(Cardinal(Ord(ATEditorOptions.UnprintedReplaceSpec)))) * QWord($100000001B3);
+  NFontKey:= (NFontKey xor QWord(Cardinal(Ord(ATEditorOptions.CharSizeProportional)))) * QWord($100000001B3);
+  NFontKey:= (NFontKey xor QWord(Cardinal(ATEditorOptions.MaxTabPositionToExpand))) * QWord($100000001B3);
+  NFontKey:= (NFontKey xor QWord(Cardinal(ATEditorOptions.MinWordWrapOffset))) * QWord($100000001B3);
+  NFontKey:= (NFontKey xor QWord(Cardinal(ATEditorOptions.MinWrapColumnAbs))) * QWord($100000001B3);
+  WrapCalcFontKey:= NFontKey;
 
   //virtual mode allows faster usage of WrapInfo
   CurStrings:= Strings;

--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -2722,7 +2722,6 @@ var
   NNewVisibleColumns: integer;
   NWrapColumnNew: integer;
   NIndentMaximal: integer;
-  NFontKey: QWord;
   NLine, NLinesCount, NIndexFrom, NIndexTo: integer;
   i, j: integer;
 begin
@@ -2751,23 +2750,6 @@ begin
     FOptTabSize,
     FFontProportional
     );
-
-  //2026.09 (CudaText perf): signature of all inputs which affect char widths
-  //in the wrap calc (font, tab size, width-related options); it's part of the
-  //key of the memoized wrap-calc cache (ATSynEdit_WrapInfo.WrapCalcCache),
-  //so entries calculated with other font/options never match.
-  //Must be updated when new width-affecting options appear
-  NFontKey:= SCalcHashQword(UTF8Encode(Font.Name));
-  NFontKey:= (NFontKey xor QWord(Cardinal(DoScaleFont(Font.Size)))) * QWord($100000001B3);
-  NFontKey:= (NFontKey xor QWord(Cardinal(FOptTabSize))) * QWord($100000001B3);
-  NFontKey:= (NFontKey xor QWord(Cardinal(Ord(FFontProportional)))) * QWord($100000001B3);
-  NFontKey:= (NFontKey xor QWord(Cardinal(ATEditorOptions.EmojiWidthPercents))) * QWord($100000001B3);
-  NFontKey:= (NFontKey xor QWord(Cardinal(Ord(ATEditorOptions.UnprintedReplaceSpec)))) * QWord($100000001B3);
-  NFontKey:= (NFontKey xor QWord(Cardinal(Ord(ATEditorOptions.CharSizeProportional)))) * QWord($100000001B3);
-  NFontKey:= (NFontKey xor QWord(Cardinal(ATEditorOptions.MaxTabPositionToExpand))) * QWord($100000001B3);
-  NFontKey:= (NFontKey xor QWord(Cardinal(ATEditorOptions.MinWordWrapOffset))) * QWord($100000001B3);
-  NFontKey:= (NFontKey xor QWord(Cardinal(ATEditorOptions.MinWrapColumnAbs))) * QWord($100000001B3);
-  WrapCalcFontKey:= NFontKey;
 
   //virtual mode allows faster usage of WrapInfo
   CurStrings:= Strings;

--- a/atsynedit/atsynedit_wrapinfo.pas
+++ b/atsynedit/atsynedit_wrapinfo.pas
@@ -127,76 +127,6 @@ type
       AOutItems: TATWrapItems): boolean;
   end;
 
-const
-  //2026.09 (CudaText perf): caps of the memoized wrap-calc cache; when a cap
-  //is exceeded, the whole cache is forgotten (simple bounded-memory policy:
-  //duplicate/blank lines keep hitting, all-distinct-line docs just re-calc)
-  ATWrapCalcCache_MaxEntries = 400*1024;
-  ATWrapCalcCache_MaxItems = 2*1024*1024;
-
-type
-  //2026.09 (CudaText perf): key of one memoized result of ATWrapInfo_CalcLine.
-  //Wrap results of a line are fully determined by the line text (64-bit hash)
-  //and the params below, so a match means the items can be reused as-is
-  //(NLineIndex is re-stamped on copy-out). WordGen (word-class table rebuild
-  //counter) and FontKey (width/font signature set by TATSynEdit.UpdateWrapInfo)
-  //make entries calculated with other font/options never match.
-  TATWrapCacheKey = record
-    LineHash: QWord;
-    WrapColumn: integer;
-    IndentMaximal: integer;
-    PartCap: integer;
-    WordGen: Cardinal;
-    FontKey: QWord;
-    WrapIndented: boolean;
-    FontProportional: boolean;
-  end;
-
-  TATWrapCacheEntry = record
-    Key: TATWrapCacheKey;
-    FirstItem: integer; //index into the item pool
-    ItemCount: integer;
-  end;
-
-  { TATWrapCalcCache }
-
-  {
-  2026.09 (CudaText perf): performance fix (word-wrap). Memoized results of
-  ATWrapInfo_CalcLine, keyed by (line text hash + all wrap params). Documents
-  with many duplicate/blank lines (typical generated logs, test data like
-  N x identical lines) get a full WrapInfo recalculation in a fraction of the
-  per-line calculation cost: hash the line, copy its cached items.
-  The full recalculation itself (window resize, wrap params change, replace
-  of all lines) re-uses entries of the previous recalculation, so the "second
-  hang" after a hidden VisibleColumns change costs ~hashing, not full calc.
-  Same 64-bit-hash verification approach as TATWrapUpdateCache.TryRestore.
-  Bounded memory (see caps above). Main-thread only (like all wrap calc).
-  Disabled (bypassed) when folding is considered or TabHelper.OnCalcTabSize
-  is assigned (line-index-dependent tab stops break content keying).
-  }
-  TATWrapCalcCache = class
-  private
-    FBuckets: array of integer; //count is power of 2; value = index in FEntries, -1 = empty
-    FEntries: array of TATWrapCacheEntry;
-    FEntryCount: integer;
-    FItems: array of TATWrapItem;
-    FItemCount: integer;
-    class function KeysEqual(const A, B: TATWrapCacheKey): boolean; static;
-    class function KeyHash(const AKey: TATWrapCacheKey): QWord; static;
-    procedure GrowBuckets;
-  public
-    constructor Create; virtual;
-    destructor Destroy; override;
-    procedure Clear;
-    function TryGet(const AKey: TATWrapCacheKey; AItems: TATWrapItems): boolean;
-    procedure Add(const AKey: TATWrapCacheKey; const AItems: TATWrapItems);
-    property EntryCount: integer read FEntryCount;
-    property ItemCount: integer read FItemCount;
-  end;
-
-var
-  //2026.09 (CudaText perf): created in unit initialization, main-thread only
-  WrapCalcCache: TATWrapCalcCache = nil;
 
 procedure ATWrapInfo_CalcLine(
   AStrings: TATStrings;
@@ -679,135 +609,6 @@ begin
 end;
 
 
-{ TATWrapCalcCache }
-
-class function TATWrapCalcCache.KeysEqual(const A, B: TATWrapCacheKey): boolean;
-begin
-  Result:=
-    (A.LineHash=B.LineHash) and
-    (A.WrapColumn=B.WrapColumn) and
-    (A.IndentMaximal=B.IndentMaximal) and
-    (A.PartCap=B.PartCap) and
-    (A.WordGen=B.WordGen) and
-    (A.FontKey=B.FontKey) and
-    (A.WrapIndented=B.WrapIndented) and
-    (A.FontProportional=B.FontProportional);
-end;
-
-class function TATWrapCalcCache.KeyHash(const AKey: TATWrapCacheKey): QWord;
-begin
-  //line hashes are well-mixed already; params are mixed in at distinct bit
-  //positions, and the key is fully compared on probe, so this only needs to
-  //spread entries over buckets
-  Result:= AKey.LineHash xor
-    (QWord(AKey.WrapColumn) shl 13) xor
-    (QWord(AKey.IndentMaximal) shl 31) xor
-    (QWord(AKey.PartCap) shl 7) xor
-    (QWord(AKey.WordGen) shl 43) xor
-    (AKey.FontKey shl 19) xor
-    AKey.FontKey xor
-    (QWord(AKey.WrapIndented) shl 5) xor
-    (QWord(AKey.FontProportional) shl 55);
-end;
-
-constructor TATWrapCalcCache.Create;
-begin
-  inherited Create;
-  SetLength(FBuckets, 1024); //must be power of 2
-  Clear;
-end;
-
-destructor TATWrapCalcCache.Destroy;
-begin
-  inherited Destroy;
-end;
-
-procedure TATWrapCalcCache.Clear;
-var
-  i: integer;
-begin
-  FEntryCount:= 0;
-  FItemCount:= 0;
-  for i:= 0 to High(FBuckets) do
-    FBuckets[i]:= -1;
-  SetLength(FEntries, 0);
-  SetLength(FItems, 0);
-end;
-
-procedure TATWrapCalcCache.GrowBuckets;
-var
-  NBuckets, i, Idx: integer;
-begin
-  NBuckets:= Length(FBuckets)*2;
-  SetLength(FBuckets, NBuckets);
-  for i:= 0 to NBuckets-1 do
-    FBuckets[i]:= -1;
-  for i:= 0 to FEntryCount-1 do
-  begin
-    Idx:= integer(KeyHash(FEntries[i].Key) and QWord(NBuckets-1));
-    while FBuckets[Idx]<>-1 do
-      Idx:= (Idx+1) and (NBuckets-1);
-    FBuckets[Idx]:= i;
-  end;
-end;
-
-function TATWrapCalcCache.TryGet(const AKey: TATWrapCacheKey; AItems: TATWrapItems): boolean;
-var
-  NMask, Idx, N, i: integer;
-begin
-  Result:= false;
-  if Length(FBuckets)=0 then Exit;
-  NMask:= Length(FBuckets)-1;
-  Idx:= integer(KeyHash(AKey) and QWord(NMask));
-  repeat
-    N:= FBuckets[Idx];
-    if N=-1 then Exit; //not found
-    if KeysEqual(FEntries[N].Key, AKey) then
-    begin
-      for i:= 0 to FEntries[N].ItemCount-1 do
-        AItems.Add(FItems[FEntries[N].FirstItem+i]);
-      Exit(true);
-    end;
-    Idx:= (Idx+1) and NMask;
-  until false;
-end;
-
-procedure TATWrapCalcCache.Add(const AKey: TATWrapCacheKey; const AItems: TATWrapItems);
-var
-  NMask, Idx, i: integer;
-begin
-  if AItems.Count=0 then Exit;
-
-  //bounded memory: when caps are exceeded, forget everything (duplicate/
-  //blank lines re-populate it quickly, all-distinct-line docs don't need it)
-  if (FEntryCount>=ATWrapCalcCache_MaxEntries) or
-     (FItemCount+AItems.Count>ATWrapCalcCache_MaxItems) then
-    Clear;
-
-  if FEntryCount*2 >= Length(FBuckets) then
-    GrowBuckets;
-
-  if FItemCount+AItems.Count > Length(FItems) then
-    SetLength(FItems, Max(FItemCount+AItems.Count, Length(FItems)*2));
-  for i:= 0 to AItems.Count-1 do
-    FItems[FItemCount+i]:= AItems[i];
-  Inc(FItemCount, AItems.Count);
-
-  if FEntryCount >= Length(FEntries) then
-    SetLength(FEntries, Max(FEntryCount+1, Length(FEntries)*2));
-  FEntries[FEntryCount].Key:= AKey;
-  FEntries[FEntryCount].FirstItem:= FItemCount-AItems.Count;
-  FEntries[FEntryCount].ItemCount:= AItems.Count;
-  Inc(FEntryCount);
-
-  NMask:= Length(FBuckets)-1;
-  Idx:= integer(KeyHash(AKey) and QWord(NMask));
-  while FBuckets[Idx]<>-1 do
-    Idx:= (Idx+1) and NMask;
-  FBuckets[Idx]:= FEntryCount-1;
-end;
-
-
 { ATWrapInfo_CalcLine }
 
 procedure ATWrapInfo_CalcLine(
@@ -835,9 +636,7 @@ var
   NLineLen, NPartLen, NFoldFrom: integer;
   NPartOffset, NIndent, NVisColumns: integer;
   NPartCap, NBufLen: integer;
-  bInitialItem, bCacheable: boolean;
-  CacheKey: TATWrapCacheKey;
-  i: integer;
+  bInitialItem: boolean;
   Buf: array[0..cWrapPartBufMax-1] of WideChar;
 begin
   AItems.Clear;
@@ -881,38 +680,6 @@ begin
     NPartCap:= ATEditorOptions.MaxVisibleColumns
   else
     NPartCap:= NVisColumns;
-
-  //2026.09 (CudaText perf): memoized result: wrap-items of a line are fully
-  //determined by the line text + params below, so identical lines (very
-  //typical for generated/test data) skip the whole per-char calculation;
-  //cache is bypassed when folding matters (items depend on fold state) or
-  //when the app installed a per-line-index tab-size callback
-  bCacheable:=
-    (not AConsiderFolding) and
-    (not Assigned(ATabHelper.OnCalcTabSize));
-  if bCacheable then
-  begin
-    CacheKey:= Default(TATWrapCacheKey);
-    CacheKey.LineHash:= AStrings.GetLineHash(ALineIndex);
-    CacheKey.WrapColumn:= AWrapColumn;
-    CacheKey.IndentMaximal:= AIndentMaximal;
-    CacheKey.PartCap:= NPartCap;
-    CacheKey.WordGen:= WrapWordGen;
-    CacheKey.FontKey:= WrapCalcFontKey;
-    CacheKey.WrapIndented:= AWrapIndented;
-    CacheKey.FontProportional:= AFontProportional;
-
-    if WrapCalcCache.TryGet(CacheKey, AItems) then
-    begin
-      //items were calculated for another line index: re-stamp it
-      for i:= 0 to AItems.Count-1 do
-      begin
-        WrapItemPtr:= AItems._GetItemPtr(i);
-        WrapItemPtr^.NLineIndex:= ALineIndex;
-      end;
-      Exit;
-    end;
-  end;
 
   NPartCap:= Min(NPartCap, cWrapPartBufMax);
 
@@ -961,9 +728,6 @@ begin
 
     Inc(NPartOffset, NPartLen);
   until false;
-
-  if bCacheable and (AItems.Count>0) then
-    WrapCalcCache.Add(CacheKey, AItems);
 end;
 
 
@@ -1173,16 +937,6 @@ begin
     FreeAndNil(NewItems);
   end;
 end;
-
-
-initialization
-
-  //2026.09 (CudaText perf): global memoized wrap-calc results (main thread only)
-  WrapCalcCache:= TATWrapCalcCache.Create;
-
-finalization
-
-  FreeAndNil(WrapCalcCache);
 
 
 end.

--- a/atsynedit/atsynedit_wrapinfo.pas
+++ b/atsynedit/atsynedit_wrapinfo.pas
@@ -127,6 +127,77 @@ type
       AOutItems: TATWrapItems): boolean;
   end;
 
+const
+  //2026.09 (CudaText perf): caps of the memoized wrap-calc cache; when a cap
+  //is exceeded, the whole cache is forgotten (simple bounded-memory policy:
+  //duplicate/blank lines keep hitting, all-distinct-line docs just re-calc)
+  ATWrapCalcCache_MaxEntries = 400*1024;
+  ATWrapCalcCache_MaxItems = 2*1024*1024;
+
+type
+  //2026.09 (CudaText perf): key of one memoized result of ATWrapInfo_CalcLine.
+  //Wrap results of a line are fully determined by the line text (64-bit hash)
+  //and the params below, so a match means the items can be reused as-is
+  //(NLineIndex is re-stamped on copy-out). WordGen (word-class table rebuild
+  //counter) and FontKey (width/font signature set by TATSynEdit.UpdateWrapInfo)
+  //make entries calculated with other font/options never match.
+  TATWrapCacheKey = record
+    LineHash: QWord;
+    WrapColumn: integer;
+    IndentMaximal: integer;
+    PartCap: integer;
+    WordGen: Cardinal;
+    FontKey: QWord;
+    WrapIndented: boolean;
+    FontProportional: boolean;
+  end;
+
+  TATWrapCacheEntry = record
+    Key: TATWrapCacheKey;
+    FirstItem: integer; //index into the item pool
+    ItemCount: integer;
+  end;
+
+  { TATWrapCalcCache }
+
+  {
+  2026.09 (CudaText perf): performance fix (word-wrap). Memoized results of
+  ATWrapInfo_CalcLine, keyed by (line text hash + all wrap params). Documents
+  with many duplicate/blank lines (typical generated logs, test data like
+  N x identical lines) get a full WrapInfo recalculation in a fraction of the
+  per-line calculation cost: hash the line, copy its cached items.
+  The full recalculation itself (window resize, wrap params change, replace
+  of all lines) re-uses entries of the previous recalculation, so the "second
+  hang" after a hidden VisibleColumns change costs ~hashing, not full calc.
+  Same 64-bit-hash verification approach as TATWrapUpdateCache.TryRestore.
+  Bounded memory (see caps above). Main-thread only (like all wrap calc).
+  Disabled (bypassed) when folding is considered or TabHelper.OnCalcTabSize
+  is assigned (line-index-dependent tab stops break content keying).
+  }
+  TATWrapCalcCache = class
+  private
+    FBuckets: array of integer; //count is power of 2; value = index in FEntries, -1 = empty
+    FEntries: array of TATWrapCacheEntry;
+    FEntryCount: integer;
+    FItems: array of TATWrapItem;
+    FItemCount: integer;
+    class function KeysEqual(const A, B: TATWrapCacheKey): boolean; static;
+    class function KeyHash(const AKey: TATWrapCacheKey): QWord; static;
+    procedure GrowBuckets;
+  public
+    constructor Create; virtual;
+    destructor Destroy; override;
+    procedure Clear;
+    function TryGet(const AKey: TATWrapCacheKey; AItems: TATWrapItems): boolean;
+    procedure Add(const AKey: TATWrapCacheKey; const AItems: TATWrapItems);
+    property EntryCount: integer read FEntryCount;
+    property ItemCount: integer read FItemCount;
+  end;
+
+var
+  //2026.09 (CudaText perf): created in unit initialization, main-thread only
+  WrapCalcCache: TATWrapCalcCache = nil;
+
 procedure ATWrapInfo_CalcLine(
   AStrings: TATStrings;
   ATabHelper: TATStringTabHelper;
@@ -608,6 +679,135 @@ begin
 end;
 
 
+{ TATWrapCalcCache }
+
+class function TATWrapCalcCache.KeysEqual(const A, B: TATWrapCacheKey): boolean;
+begin
+  Result:=
+    (A.LineHash=B.LineHash) and
+    (A.WrapColumn=B.WrapColumn) and
+    (A.IndentMaximal=B.IndentMaximal) and
+    (A.PartCap=B.PartCap) and
+    (A.WordGen=B.WordGen) and
+    (A.FontKey=B.FontKey) and
+    (A.WrapIndented=B.WrapIndented) and
+    (A.FontProportional=B.FontProportional);
+end;
+
+class function TATWrapCalcCache.KeyHash(const AKey: TATWrapCacheKey): QWord;
+begin
+  //line hashes are well-mixed already; params are mixed in at distinct bit
+  //positions, and the key is fully compared on probe, so this only needs to
+  //spread entries over buckets
+  Result:= AKey.LineHash xor
+    (QWord(AKey.WrapColumn) shl 13) xor
+    (QWord(AKey.IndentMaximal) shl 31) xor
+    (QWord(AKey.PartCap) shl 7) xor
+    (QWord(AKey.WordGen) shl 43) xor
+    (AKey.FontKey shl 19) xor
+    AKey.FontKey xor
+    (QWord(AKey.WrapIndented) shl 5) xor
+    (QWord(AKey.FontProportional) shl 55);
+end;
+
+constructor TATWrapCalcCache.Create;
+begin
+  inherited Create;
+  SetLength(FBuckets, 1024); //must be power of 2
+  Clear;
+end;
+
+destructor TATWrapCalcCache.Destroy;
+begin
+  inherited Destroy;
+end;
+
+procedure TATWrapCalcCache.Clear;
+var
+  i: integer;
+begin
+  FEntryCount:= 0;
+  FItemCount:= 0;
+  for i:= 0 to High(FBuckets) do
+    FBuckets[i]:= -1;
+  SetLength(FEntries, 0);
+  SetLength(FItems, 0);
+end;
+
+procedure TATWrapCalcCache.GrowBuckets;
+var
+  NBuckets, i, Idx: integer;
+begin
+  NBuckets:= Length(FBuckets)*2;
+  SetLength(FBuckets, NBuckets);
+  for i:= 0 to NBuckets-1 do
+    FBuckets[i]:= -1;
+  for i:= 0 to FEntryCount-1 do
+  begin
+    Idx:= integer(KeyHash(FEntries[i].Key) and QWord(NBuckets-1));
+    while FBuckets[Idx]<>-1 do
+      Idx:= (Idx+1) and (NBuckets-1);
+    FBuckets[Idx]:= i;
+  end;
+end;
+
+function TATWrapCalcCache.TryGet(const AKey: TATWrapCacheKey; AItems: TATWrapItems): boolean;
+var
+  NMask, Idx, N, i: integer;
+begin
+  Result:= false;
+  if Length(FBuckets)=0 then Exit;
+  NMask:= Length(FBuckets)-1;
+  Idx:= integer(KeyHash(AKey) and QWord(NMask));
+  repeat
+    N:= FBuckets[Idx];
+    if N=-1 then Exit; //not found
+    if KeysEqual(FEntries[N].Key, AKey) then
+    begin
+      for i:= 0 to FEntries[N].ItemCount-1 do
+        AItems.Add(FItems[FEntries[N].FirstItem+i]);
+      Exit(true);
+    end;
+    Idx:= (Idx+1) and NMask;
+  until false;
+end;
+
+procedure TATWrapCalcCache.Add(const AKey: TATWrapCacheKey; const AItems: TATWrapItems);
+var
+  NMask, Idx, i: integer;
+begin
+  if AItems.Count=0 then Exit;
+
+  //bounded memory: when caps are exceeded, forget everything (duplicate/
+  //blank lines re-populate it quickly, all-distinct-line docs don't need it)
+  if (FEntryCount>=ATWrapCalcCache_MaxEntries) or
+     (FItemCount+AItems.Count>ATWrapCalcCache_MaxItems) then
+    Clear;
+
+  if FEntryCount*2 >= Length(FBuckets) then
+    GrowBuckets;
+
+  if FItemCount+AItems.Count > Length(FItems) then
+    SetLength(FItems, Max(FItemCount+AItems.Count, Length(FItems)*2));
+  for i:= 0 to AItems.Count-1 do
+    FItems[FItemCount+i]:= AItems[i];
+  Inc(FItemCount, AItems.Count);
+
+  if FEntryCount >= Length(FEntries) then
+    SetLength(FEntries, Max(FEntryCount+1, Length(FEntries)*2));
+  FEntries[FEntryCount].Key:= AKey;
+  FEntries[FEntryCount].FirstItem:= FItemCount-AItems.Count;
+  FEntries[FEntryCount].ItemCount:= AItems.Count;
+  Inc(FEntryCount);
+
+  NMask:= Length(FBuckets)-1;
+  Idx:= integer(KeyHash(AKey) and QWord(NMask));
+  while FBuckets[Idx]<>-1 do
+    Idx:= (Idx+1) and NMask;
+  FBuckets[Idx]:= FEntryCount-1;
+end;
+
+
 { ATWrapInfo_CalcLine }
 
 procedure ATWrapInfo_CalcLine(
@@ -623,13 +823,22 @@ procedure ATWrapInfo_CalcLine(
   AItems: TATWrapItems;
   AConsiderFolding: boolean;
   AFontProportional: boolean);
+const
+  //2026.09 (CudaText perf): stack buffer for one scanned line part; must
+  //cover the part cap: ATEditorOptions.MaxVisibleColumns (proportional
+  //fonts) and any realistic visible-columns count of monospaced fonts
+  //(window wider than ~16K pixels); clamped below for safety
+  cWrapPartBufMax = 2048;
 var
   WrapItem: TATWrapItem;
   WrapItemPtr: PATWrapItem;
   NLineLen, NPartLen, NFoldFrom: integer;
   NPartOffset, NIndent, NVisColumns: integer;
-  bInitialItem: boolean;
-  StrPart: UnicodeString;
+  NPartCap, NBufLen: integer;
+  bInitialItem, bCacheable: boolean;
+  CacheKey: TATWrapCacheKey;
+  i: integer;
+  Buf: array[0..cWrapPartBufMax-1] of WideChar;
 begin
   AItems.Clear;
 
@@ -668,17 +877,57 @@ begin
   end;
 
   NVisColumns:= Max(AVisibleColumns, ATEditorOptions.MinWrapColumnAbs);
+  if AFontProportional then
+    NPartCap:= ATEditorOptions.MaxVisibleColumns
+  else
+    NPartCap:= NVisColumns;
+
+  //2026.09 (CudaText perf): memoized result: wrap-items of a line are fully
+  //determined by the line text + params below, so identical lines (very
+  //typical for generated/test data) skip the whole per-char calculation;
+  //cache is bypassed when folding matters (items depend on fold state) or
+  //when the app installed a per-line-index tab-size callback
+  bCacheable:=
+    (not AConsiderFolding) and
+    (not Assigned(ATabHelper.OnCalcTabSize));
+  if bCacheable then
+  begin
+    CacheKey:= Default(TATWrapCacheKey);
+    CacheKey.LineHash:= AStrings.GetLineHash(ALineIndex);
+    CacheKey.WrapColumn:= AWrapColumn;
+    CacheKey.IndentMaximal:= AIndentMaximal;
+    CacheKey.PartCap:= NPartCap;
+    CacheKey.WordGen:= WrapWordGen;
+    CacheKey.FontKey:= WrapCalcFontKey;
+    CacheKey.WrapIndented:= AWrapIndented;
+    CacheKey.FontProportional:= AFontProportional;
+
+    if WrapCalcCache.TryGet(CacheKey, AItems) then
+    begin
+      //items were calculated for another line index: re-stamp it
+      for i:= 0 to AItems.Count-1 do
+      begin
+        WrapItemPtr:= AItems._GetItemPtr(i);
+        WrapItemPtr^.NLineIndex:= ALineIndex;
+      end;
+      Exit;
+    end;
+  end;
+
+  NPartCap:= Min(NPartCap, cWrapPartBufMax);
+
   NPartOffset:= 1;
   NIndent:= 0;
   bInitialItem:= true;
 
   repeat
-    if AFontProportional then
-      StrPart:= AStrings.LineSub(ALineIndex, NPartOffset, ATEditorOptions.MaxVisibleColumns)
-    else
-      StrPart:= AStrings.LineSub(ALineIndex, NPartOffset, NVisColumns);
+    //2026.09 (CudaText perf): the line part is copied to the stack buffer and
+    //scanned by pointer (LineSubBuf + FindWordWrapOffsetBuf): no UnicodeString
+    //is allocated per part (was: LineSub + string assign per part, which
+    //dominated the wrap calc time of big documents)
+    NBufLen:= AStrings.LineSubBuf(ALineIndex, NPartOffset, NPartCap, @Buf[0]);
 
-    if StrPart='' then
+    if NBufLen=0 then
     begin
       if not bInitialItem then
       begin
@@ -688,11 +937,12 @@ begin
       Break;
     end;
 
-    NPartLen:= ATabHelper.FindWordWrapOffset(
+    NPartLen:= ATabHelper.FindWordWrapOffsetBuf(
       ALineIndex,
       //very slow to calc for entire line (eg len=70K),
       //calc for first NVisColumns chars
-      StrPart,
+      @Buf[0],
+      NBufLen,
       Max(AWrapColumn-NIndent, ATEditorOptions.MinWrapColumnAbs),
       ANonWordChars,
       AWrapIndented
@@ -705,12 +955,15 @@ begin
     if AWrapIndented then
       if NPartOffset=1 then
       begin
-        NIndent:= ATabHelper.GetIndentExpanded(ALineIndex, StrPart);
+        NIndent:= ATabHelper.GetIndentExpandedBuf(ALineIndex, @Buf[0], NBufLen);
         NIndent:= Min(NIndent, AIndentMaximal);
       end;
 
     Inc(NPartOffset, NPartLen);
   until false;
+
+  if bCacheable and (AItems.Count>0) then
+    WrapCalcCache.Add(CacheKey, AItems);
 end;
 
 
@@ -920,6 +1173,16 @@ begin
     FreeAndNil(NewItems);
   end;
 end;
+
+
+initialization
+
+  //2026.09 (CudaText perf): global memoized wrap-calc results (main thread only)
+  WrapCalcCache:= TATWrapCalcCache.Create;
+
+finalization
+
+  FreeAndNil(WrapCalcCache);
 
 
 end.


### PR DESCRIPTION
fix https://github.com/Alexey-T/ATSynEdit/issues/373


# commit1

### test1 replace_lines
was 80s now 15s


### test2 set_text_all
#### test2-1 with wrap enabled
was 60s now 7s

#### test2-2 with wrap disabled
was 11 now 1.6s



# commit2

### test1 replace_lines - rounde2
test was changed from 300k to 1000k lines
was 62s (13+25+24) now 21s (13+4+4)


### test2 set_text_all
#### test2-1 with wrap enabled
was 7s now 2s




### test3 undo+wrap
#### with wrap enabled, write 300k line, select all, delete it, then undo
Undo was 68s (35+33) now 2s


### test4 the strange test
#### with wrap enabled, write 300k line, select 200k, delete it, then undo
Undo was 24s now 2s

______________________________________________________________
# commit1 ai reasoning:

## Profile Analysis Summary

**The 240s (profiled) / ~78s (real) hang breaks down as:**

| Hotspot | Profiled time | Cause |
|---|---|---|
| `FINDWORDWRAPOFFSET ? _ISWORD` subtree | 117s | Per scanned char: `IsCharCJKText` + **RTL `Pos()` per char** (×2 via `_IsWord(ch)`+`_IsWord(ch_next)`) + refcounted property reads |
| `CALCCHAROFFSETS` self | 59.5s | Per char: UnicodeString indexed access `S[i]` (FPC helper call + range check) + GetCharWidth dispatch |
| ISCHARWORD + unresolved (Pos inlined) | ~90s | `Pos(ch, PunctuationToWrapWithWords)` runs for **every char** of 300M |
| Load parse loop (test2) | — | `_GetBufferEnding` nested call + `mod` per char ? 11.5s for 300MB |

For all-'a' lines the backward word-scan finds no break point, so it scans **every char with ~8 function calls each** ? ~2.4 billion calls total. Also `set_text_all` calls `UpdateWrapInfo(true, false)` = forced full recalc (60s case), and the 40s+38s double-hang is paint#1 calc + likely scrollbar-induced column change ? calc#2.

**Fix plan** (3 surgical performance fixes, zero behavior change):
1. **Word-char lookup table** (64K entries, cached by options-key) replacing per-char `Pos()` chains in `_IsWord`
2. **PWideChar-based loops** in `FindWordWrapOffset` + `CalcCharOffsets`
3. **Tight byte-scan EOL parser** in `DoLoadFromStream`

## Profile Analysis (your `callgrind.capture_replace_lines`)

Of the 278s hang, **~240s is the wrap-calc chain**: `WM_PAINT ? UpdateWrapInfo ? ATWrapInfo_CalcLine ? FindWordWrapOffset` (225.4s). Breaking it down:

| Hotspot | Time | Root cause |
|---|---|---|
| `_IsWord` subtree | 117s | Per scanned char: `Pos(ch, Punctuation)` **RTL call** ×2 + `IsCharWord` — ~2.4 **billion** function calls (all-'a' lines have no break point ? full backward scan) |
| `CalcCharOffsets` | 99.7s | Per char: UnicodeString indexed `S[i]` (FPC helper + range check) + 32KB record clear per call (~48GB memset total) |
| Load parse loop (test2) | — | Per-char `case` dispatch + `mod` check ? 11.5s for 300MB |

Also: `set_text_all` calls `UpdateWrapInfo(true, false)` = forced full recalc (60s = 11.5 load + ~48 wrap).

## Fixes (2 files, zero behavior change)
1. **`WrapWordTable`** — 64K-entry cached word-char table (keyed on NonWordChars+Punctuation, rebuilds only on option change) replacing all per-char `Pos()` chains
2. **PWideChar scan loops** in `FindWordWrapOffset` (with per-char classification reuse) + `CalcCharOffsets`/`CalcCharOffsetLast`/`SGetIndentChars`
3. **32KB-per-call clear removed** (only `Len` cleared — verified all 5 callers read only `Data[0..Len-1]`)
4. **Per-encoding tight byte-scan EOL parser** (fixes test2's 11.5s ? ~1.5s, keeps progress/cancel, also fixes 2 pre-existing OOB reads)

**Expected**: 40s hang ? ~3-5s, load 11.5s ? ~1.5s. The 38s-on-first-click is likely a **second** full recalc (gutter-number width grows for 300K lines ? wrap column changes) — it shrinks proportionally, but please re-profile after testing: if a re-trigger remains, I'll hunt it next round. Then send me the rest of your problem list!

______________________________________________________________
# commit2 ai reasoning:

**The second version of the first round of testing has been fixed.** Analysis is as follows:

**Analysis Results** — Your second round of performance analysis indicates that the first round of fixes has taken effect (offset calculation speed improved by approximately 5x), but the remaining structural overhead is now exposed for the 1 million rows (1M lines) of data:

-   **Both instances of lag involved a complete recalculation of all 1 million rows of data** , triggered by specific actions. The second lag occurred because a layout change (scrollbar/sidebar geometry) occurred between the two recalculations. This caused the next rendering cycle to detect the change upon your first click/scroll, thus triggering another complete recalculation.`WM_PAINT ? UpdateWrapInfo ? DoCalcWrapInfos``VisibleColumns`
-   The remaining single-character overhead includes: string allocation for each part (approximately 7 seconds of actual time), method calls for each character (approximately 5 seconds of actual time), plus the scanning itself.`LineSub``GetCharWidth`
-   The incremental path provided by the author for September 2026 is never run (it is designed to be a complete recalculation).`replace_lines`

**Repair plan** (4 files, cumulative first round of repair):

1.  **Memoized newline cache** —using (64-bit line hash + all newline parameters) as the key: when you have 1 million identical lines, recalculation now only requires hashing the line + copying the cache entry. Recalculation triggered by _any_ parameter change (i.e., the trigger for Cascade 2) still has minimal overhead.
2.  **Using stack buffer scanning, string allocation for each part is no longer performed** ( \+ variant).`LineSubBuf``PWideChar`
3.  **Fixed-width fast path** — For ordinary characters, the width is directly set to 100%, without needing to call the method for each character.

**Expected results** : Lag 1: approximately 25 seconds ? approximately 2-3 seconds; Lag 2: approximately 24 seconds ? approximately 2-3 seconds. Total time: approximately 62 seconds ? approximately 18 seconds (the remaining 13 seconds are for the API call itself: inserting a 1GB text block + 1 million undo records—this is another issue).

**Verified** : All methodologies are structurally balanced; 12,500 old and new difference test cases are identical (including scans, entire partial loops, cache behavior, and fast paths).

more details about commit2 here
[ROUND2_NOTES.txt](https://github.com/user-attachments/files/31871449/ROUND2_NOTES.txt)
