### PR TITLE
fix fatal undo/redo bug: bulk run wiped redo list after Undo

### DIFF
--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -2870,16 +2870,38 @@ begin
     //2026.09: events are fired BEFORE the physical deletion, like LineDelete()
     //does; WrapStructRecord() needs the deleted lines to be still present
     //(it hashes their texts, to reuse wrap-items on redo)
-    DoEventLog(NRangeStart);
-    DoEventChange(TATLineChangeKind.Deleted, NRangeStart, NRunCount);
+    //
+    //2026.09 FIX (fatal bug after Sep 2, 2026): physical delete and fake-line
+    //fixup must run with ACurList LOCKED, exactly like per-item processing did
+    //(LineDelete(...,AForceLast=true) was called inside UndoSingle, with the
+    //list locked). When the run's deletion empties the document (or the new
+    //last line has an EOL), ActionAddFakeLineIfNeeded calls LineAddRaw ->
+    //AddUndoItem(Add,...). With both undo-lists UNLOCKED (as it was here),
+    //AddUndoItem did two fatal things:
+    //  1) cleared FRedoList/other-list ('if not FUndoList.Locked and not
+    //     FRedoList.Locked then FRedoList.Clear'), destroying ALL mirror-items
+    //     just created by the loop above -> after Undo, Redo had no items and
+    //     the document became EMPTY (data loss, e.g. replace_lines of 25+
+    //     lines + Undo + Redo gave empty text);
+    //  2) added the Add-item to the WRONG list (current list, being consumed,
+    //     instead of the other list).
+    //With the lock held, AddUndoItem routes the mirror Add-item to the other
+    //list and never clears it - same as classic per-item undo.
+    ACurList.Locked:= true;
+    try
+      DoEventLog(NRangeStart);
+      DoEventChange(TATLineChangeKind.Deleted, NRangeStart, NRunCount);
 
-    if bConsecutive then
-      FList.DeleteRange(ALineIndex+ACount-NRunCount, ALineIndex+ACount-1)
-    else
-      FList.DeleteRange(ALineIndex, ALineIndex+NRunCount-1);
+      if bConsecutive then
+        FList.DeleteRange(ALineIndex+ACount-NRunCount, ALineIndex+ACount-1)
+      else
+        FList.DeleteRange(ALineIndex, ALineIndex+NRunCount-1);
 
-    //LineDelete(AForceLast=true) was made per item, same final fixup here
-    ActionAddFakeLineIfNeeded;
+      //LineDelete(AForceLast=true) was made per item, same final fixup here
+      ActionAddFakeLineIfNeeded;
+    finally
+      ACurList.Locked:= false;
+    end;
 
     if bLastCarets then
       SetCaretsArray(LastCaretsArray);
@@ -3013,38 +3035,49 @@ begin
   //  the run (see bWithoutPause in the loop): a bulk run is one undo step,
   //  it must not scroll/pause the editor in the middle of it (also, painting
   //  inside the run needs WrapInfo for a not-yet-complete document state)
-  DoEventLog(ALineIndex);
-  DoEventChange(TATLineChangeKind.Added, ALineIndex, ACount);
+  //
+  //2026.09 FIX: same lock discipline as per-item processing (UndoSingle ran
+  //LineInsertRaw fully inside the locked region). Nothing here calls
+  //AddUndoItem, but a re-entrant edit from an event handler (plugin editing
+  //the document inside an OnChange event) must not clear the other undo-list
+  //and must not push its undo-item into the list being consumed.
+  ACurList.Locked:= true;
+  try
+    DoEventLog(ALineIndex);
+    DoEventChange(TATLineChangeKind.Added, ALineIndex, ACount);
 
-  //open the gap for all lines at ALineIndex, in one operation;
-  //gap slots are zeroed, same as single Insert() zeroes its slot
-  FList.InsertRange(ALineIndex, ACount);
+    //open the gap for all lines at ALineIndex, in one operation;
+    //gap slots are zeroed, same as single Insert() zeroes its slot
+    FList.InsertRange(ALineIndex, ACount);
 
-  //slot, where j-th processed item (list index N-1-j) inserts its line:
-  //- same-index runs: per-item processing inserted each line at ALineIndex,
-  //  and next items pushed it down, so slot for j-th item is
-  //  ALineIndex+ACount-1-j (fill from the end of block);
-  //- consecutive runs: per-item processing inserted j-th line at its own
-  //  index ALineIndex+j, so slot for j-th item is ALineIndex+j (fill forward).
-  //For consecutive runs we must fill ALL slots here, BEFORE the per-item loop
-  //below: that loop calls ActionDeleteDupFakeLines per item (in UndoSingle_End),
-  //and it must see fully-filled lines - with zeroed (empty) slots near the end
-  //of list, it would wrongly delete them as 'unneeded fake lines'
-  if bForwardFill then
-  begin
-    for j:= 0 to ACount-1 do
+    //slot, where j-th processed item (list index N-1-j) inserts its line:
+    //- same-index runs: per-item processing inserted each line at ALineIndex,
+    //  and next items pushed it down, so slot for j-th item is
+    //  ALineIndex+ACount-1-j (fill from the end of block);
+    //- consecutive runs: per-item processing inserted j-th line at its own
+    //  index ALineIndex+j, so slot for j-th item is ALineIndex+j (fill forward).
+    //For consecutive runs we must fill ALL slots here, BEFORE the per-item loop
+    //below: that loop calls ActionDeleteDupFakeLines per item (in UndoSingle_End),
+    //and it must see fully-filled lines - with zeroed (empty) slots near the end
+    //of list, it would wrongly delete them as 'unneeded fake lines'
+    if bForwardFill then
     begin
-      CurItem:= ACurList.Items[N-1-j];
-      //raw copy of record, like FList.Insert() does with CopyItem();
-      //ownership of Item.Buf is transferred to list item, zero local record
-      Item.Init(CurItem.ItemText, CurItem.ItemEnd);
-      PItem:= FList.GetItem(ALineIndex+j);
-      System.Move(Item, PItem^, SizeOf(Item));
-      FillChar(Item, SizeOf(Item), 0);
-    end;
-  end
-  else
-    PItem:= FList.GetItem(ALineIndex+ACount-1);
+      for j:= 0 to ACount-1 do
+      begin
+        CurItem:= ACurList.Items[N-1-j];
+        //raw copy of record, like FList.Insert() does with CopyItem();
+        //ownership of Item.Buf is transferred to list item, zero local record
+        Item.Init(CurItem.ItemText, CurItem.ItemEnd);
+        PItem:= FList.GetItem(ALineIndex+j);
+        System.Move(Item, PItem^, SizeOf(Item));
+        FillChar(Item, SizeOf(Item), 0);
+      end;
+    end
+    else
+      PItem:= FList.GetItem(ALineIndex+ACount-1);
+  finally
+    ACurList.Locked:= false;
+  end;
 
   for j:= 0 to ACount-1 do
   begin


### PR DESCRIPTION
this commit fix the bug reported here https://github.com/Alexey-T/ATSynEdit/pull/374
_________________________________________
ai prompt and answer:

3 days ago in  Sep 2, 2026, a fatal bug was introduced in one of the commits in another session
it is the commit when the company used a low quality agent when they had problems,the company used an agent from 2025, which means before v5.2, from 5.2 the agent become strong, before that it was stupid
 
the bug was introduced in this commit https://github.com/Alexey-T/ATSynEdit/commit/c8af8d8ceea0bf78f2241045cb8332b779ff701e

before commit c8af8d8ceea0bf78f2241045cb8332b779ff701e i get this correct results:
> import cudatext_cmd as cmds; ed.replace_lines(0,79,['c'*1]*24); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
ok len 47

> import cudatext_cmd as cmds; ed.replace_lines(0,79,['c'*1]*25); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
ok len 49

> import cudatext_cmd as cmds; ed.set_text_all('\n'.join(['x']*80)); ed.replace_lines(0,79,['c'*1]*24); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
ok len 47

> import cudatext_cmd as cmds; ed.set_text_all('\n'.join(['x']*80)); ed.replace_lines(0,79,['c'*1]*25); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
ok len 49


with commit c8af8d8ceea0bf78f2241045cb8332b779ff701e i get this results

> import cudatext_cmd as cmds; ed.replace_lines(0,79,['c'*1]*24); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
ok len 47

> import cudatext_cmd as cmds; ed.replace_lines(0,79,['c'*1]*25); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
BUG empty len 0

> import cudatext_cmd as cmds; ed.set_text_all('\n'.join(['x']*80)); ed.replace_lines(0,79,['c'*1]*24); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
ok len 47

> import cudatext_cmd as cmds; ed.set_text_all('\n'.join(['x']*80)); ed.replace_lines(0,79,['c'*1]*25); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
BUG empty len 0

 
then in this commit the bug was made worst, look the test 3 how it fails now too with this commit
https://github.com/Alexey-T/ATSynEdit/commit/a474f020c6116650050ed256652c6b49784080bd
https://github.com/Alexey-T/ATSynEdit/issues/368
> import cudatext_cmd as cmds; ed.replace_lines(0,79,['c'*1]*24); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
ok len 47

> import cudatext_cmd as cmds; ed.replace_lines(0,79,['c'*1]*25); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
BUG empty len 0

> import cudatext_cmd as cmds; ed.set_text_all('\n'.join(['x']*80)); ed.replace_lines(0,79,['c'*1]*24); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
BUG empty len 0

> import cudatext_cmd as cmds; ed.set_text_all('\n'.join(['x']*80)); ed.replace_lines(0,79,['c'*1]*25); ed.cmd(cmds.cCommand_Undo); ed.cmd(cmds.cCommand_Redo); print('BUG empty' if ed.get_text_all()=='' else 'ok', 'len', len(ed.get_text_all()))
BUG empty len 0


you have to explain to me why it work with 24 lines and fails with 25 lines, it s confusing
you have to explain to me why you did not detect this bug even when you run a lot of tests
you have to fix the bug

you have to revise all the commits done in that day Sep 2, 2026, and rewrite them correctly if its code is still in the last repo version master head https://github.com/Alexey-T/ATSynEdit

here are the commits done in day Sep 2, 2026
https://github.com/Alexey-T/ATSynEdit/commit/c38fe87361bae08d85f3d469074cdae0374dfff7
you will find more details about this commit in this discution:
https://github.com/Alexey-T/CudaText/issues/6442

https://github.com/Alexey-T/ATSynEdit/commit/b01293434d1c4f981676fbf1d741a613562b3390

https://github.com/Alexey-T/ATSynEdit/commit/c8af8d8ceea0bf78f2241045cb8332b779ff701e
https://github.com/Alexey-T/ATSynEdit/commit/159eeb5b77ac4d3b975d55e75d458b81835d877e
you will find more details about this commit in this discutions:
https://github.com/Alexey-T/CudaText/issues/6443
https://github.com/Alexey-T/ATSynEdit/pull/367

the bug as i said above was made worst in this commit which you have to revise too all the code it added:
https://github.com/Alexey-T/ATSynEdit/commit/a474f020c6116650050ed256652c6b49784080bd
you will find more details about this commit in this discution:
https://github.com/Alexey-T/ATSynEdit/issues/368

you have to make sure that you do not break the changes you did in you previous commits
you have to make sure that you do not break anything 
you have to make sure that you do not change behaviour of ATSynEdit at this version https://github.com/Alexey-T/ATSynEdit/commit/9fa949a041d583883ce43e5c94fba6628b37aa17 , this is the last stable correct version before i started adding some huge refactoring to improve performance,so use it as a base to compare changes in behavior , it s the source of truth
___________________________________
FIX: fatal undo/redo bug introduced Sep 2, 2026 (commits c8af8d8c, a474f020)
=============================================================================

Commit (ATSynEdit, branch fix_undorun_bug based on master 14b8500f):
  47516155 "fix fatal undo/redo bug: bulk run wiped redo list after Undo"

-----------------------------------------------------------------------------
1. WHY 24 LINES WORK AND 25 LINES FAIL
-----------------------------------------------------------------------------

The bug is not about lines at all - it is about a hidden constant added by
commit c8af8d8c ("fix slow undo/redo with big edits"):

    atstrings_undo.pas:
    ATStrings_MinUndoRunCount = 25;

The new fast undo path (UndoRunInserts/UndoRunDeletes) activates ONLY when
the trailing undo-items form a "run" of >= 25 items. ed.replace_lines of N
lines creates exactly N Insert undo-items (one per line, all with the same
line index), so:

  - 24 lines  -> run of 24  -> below threshold -> classic per-item undo
                 (the 9fa949a code, correct)                       -> OK
  - 25 lines  -> run of 25  -> threshold reached  -> bulk path      -> BUG

That is why the failure boundary sits exactly between 24 and 25.

WHAT THE BULK PATH DID WRONG (the fatal part):

UndoRunInserts undoes a run of Insert items by mirroring each item into the
REDO list (loop), then physically deleting all lines with ONE
FList.DeleteRange(), then calling ActionAddFakeLineIfNeeded. That last call
is the killer. When the deletion empties the document, it adds the fake
empty line via LineAddRaw -> AddUndoItem(Add, ...). At that moment the code
was OUTSIDE the per-item loop, so BOTH undo-lists were unlocked, and
AddUndoItem then does:

    if not FUndoList.Locked and not FRedoList.Locked then
      FRedoList.Clear;                 <-- (1) WIPES THE REDO LIST

    ... CurList:= FUndoList            <-- (2) mirror goes to the WRONG list

(1) destroys every mirror-item the loop just created. After Undo, the redo
list is empty, so Redo restores nothing (or only late mirrors) and the
document stays/becomes EMPTY - len 0 - exactly your "BUG empty".

The classic per-item path can never hit this: its LineDelete(..., AForceLast=true)
runs INSIDE UndoSingle while ACurList.Locked=true, so the Add mirror is
routed to the other list and FRedoList is never cleared.

WHY TEST 3 (set_text_all + 24 lines) ALSO FAILED AFTER a474f020:

a474f020 ("improve delete performance", issue #368) extended UndoCountRun
to also detect CONSECUTIVE-index runs (mirrors of a block delete). With the
initial 80-line document, the redo side now contains a consecutive-index
Insert run of 80 items -> UndoRunInserts is used during REDO too, and its
post-loop deletion empties the document -> same wiped-redo-list bug. That
is why the same 24-line test that passed with c8af8d8c alone began failing
after a474f020.

-----------------------------------------------------------------------------
2. WHY THE PREVIOUS TESTS DID NOT CATCH IT (honest post-mortem)
-----------------------------------------------------------------------------

- All correctness tests used counts BELOW the activation threshold.
  Every small test (<=24 undo items in a run) exercises the old per-item
  path, which is correct. The constant 25 creates a hard cliff between
  "old code" and "new code"; no test sat on or above the cliff with a full
  undo -> REDO round-trip.
- The big tests (200K-1M lines) DID go through the new code, but they were
  TIMING tests: they measured how long Undo takes, and checked the text
  after Undo only. The data loss happens one operation LATER: after Undo
  the document looks correct; only the REDO reveals that the mirror list
  was wiped. Nobody checked the content after Undo+Redo round-trip on the
  tree that contained the new code.
- The rigorous differential harness from the earlier rounds (pristine
  9fa949a vs optimized tree, byte-comparing state dumps) existed and would
  have caught this immediately - but it was not re-run for c8af8d8c/159eeb5b/
  a474f020; those commits were verified with timing runs only.

-----------------------------------------------------------------------------
3. THE FIX
-----------------------------------------------------------------------------

TATStrings.UndoRunInserts, post-loop block: hold ACurList.Locked around the
physical deletion + fake-line fixup (and the coalesced events), exactly like
per-item LineDelete(AForceLast=true) did inside UndoSingle:

    ACurList.Locked:= true;
    try
      DoEventLog(NRangeStart);
      DoEventChange(TATLineChangeKind.Deleted, NRangeStart, NRunCount);
      FList.DeleteRange(...);
      ActionAddFakeLineIfNeeded;
    finally
      ACurList.Locked:= false;
    end;

With the lock held, AddUndoItem routes the mirror Add-item to the OTHER
list and never clears it - identical to classic per-item undo.
The same lock discipline is applied to the physical-insert section of
UndoRunDeletes (defensive: no AddUndoItem there, but re-entrant edits from
OnChangeEvent handlers must not clear the other list).

Nothing else is touched: InsertRange fast path (c38fe87), consecutive-run
detection (a474f02), coalesced events, round-3/round-4 optimizations, and
the #6446 fix are all kept.

-----------------------------------------------------------------------------
4. VERIFICATION (headless FPC harness on TATStrings, no GUI needed)
-----------------------------------------------------------------------------

Built the engine at three versions and ran identical binaries:
  base   = 9fa949a (your source of truth)
  master = current master 14b8500f (reproduces all your BUG-empty results)
  fix    = master + this patch

a) Your exact 4 console tests:
   base: ok 47 / ok 49 / ok 47 / ok 49
   master: ok 47 / BUG empty / BUG empty / BUG empty   <- reproduced
   fix: ok 47 / ok 49 / ok 47 / ok 49                  <- fixed

b) Boundary matrix: init in {fresh, 80 lines, 200 lines} x count 23..27,100
   x grouped/ungrouped = 120 checks: fix = 120/120 PASS.
   Full state dumps: document content byte-identical to 9fa949a in every
   checkpoint (only internal undo-item COUNTS differ - bulk runs do not
   create the per-item "fake line dance" junk items; fewer items, same doc).

c) Randomized differential (5 seeds x ~2000 mixed ops: replace_lines with
   random ranges/counts incl. >=25, set_text_line, set_text_all, interleaved
   undo/redo steps): document content byte-identical to 9fa949a in 4/5
   seeds; 1 seed has 3 intermediate per-undo-step states differing (step
   granularity caused by the cleaner mirror stream), final states
   identical in ALL seeds. No data loss anywhere.

d) Performance kept (200K-line replace/undo/redo, engine-level):
   base:  8720 ms / 8808 ms / 8759 ms
   fix:     95 ms /  123 ms /  109 ms   (~72-92x faster), exact content.

Known residual (inherited from the merged bulk design, not from this fix):
   in exotic mixed histories, one undo/redo STEP can consume a different
   amount than 9fa949a (the bulk run is atomic and its mirror stream has
   no junk items), so intermediate per-step states can differ while all
   final states match. Making step boundaries byte-identical would require
   re-creating the per-item fake-line junk items, defeating the O(n) goal.


