### PR TITLE
fix file_open performance when scrollbar_themed is False

### DIFF
--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -2744,6 +2744,27 @@ begin
   if FRectMain.Width=0 then
     UpdateInitialVars(Canvas);
 
+  //2026.09.10 fix (word-wrap + OS-native scrollbars):
+  //When "scrollbar_themed"=false (OptScrollbarsNew=false), editor uses
+  //OS-native scrollbar, which takes ~16px of the client area WHEN IT APPEARS
+  //(at the end of DoPaint, in UpdateScrollbarVert). This changes
+  //GetVisibleColumns(), so the full wrap recalculation runs a second time
+  //for the whole document -- doubling the file-open time for word-wrapped
+  //huge files (1M lines: 7.9s -> 14.5s). Themed scrollbars (child controls)
+  //don't have the problem: GetClientSizes() always reserves their width.
+  //Fix: for big documents, show the vertical OS-scrollbar BEFORE the wrap
+  //calculation, so the wrap uses the final client width from the start.
+  if (not FOptScrollbarsNew) and
+    (not ShowOsBarVert) and
+    (not ModeOneLine) and
+    (FOptScrollStyleVert<>TATEditorScrollbarStyle.Hide) and
+    (FWrapMode<>TATEditorWrapMode.ModeOff) and
+    (Strings.Count>GetVisibleLines) then
+  begin
+    ShowOsBarVert:= true;
+    UpdateInitialVars(Canvas); //refresh FClientW/H, FRect* for reduced client area
+  end;
+
   FCharSizer.Init(
     Font.Name,
     DoScaleFont(Font.Size),


### PR DESCRIPTION

when cudatext scrollbar_themed is false the time doubles for file_open

test:

create a 500mb, saved in temp dir

```python
import os, tempfile, random, time; fpath = os.path.join(tempfile.gettempdir(), filename); t1 = time.time(); open(fpath, "w").writelines(os.urandom(random.randint(245, 255)).hex() + "\n" for _ in range(total_lines)); print(f"saved to {fpath} in {time.time()-t1:.4f}s")
```

### 'scrollbar_themed': False
```python
filename="cuda_undo_test_rand_1M.txt";
import os, cudatext as app, cudatext_cmd as cmds, cudax_lib;
cudax_lib.set_opt('scrollbar_themed', False);
cudax_lib.set_opt('wrap_enabled_max_lines', 1100000); cudax_lib.set_opt('wrap_mode', 1); file_open(os.path.join(app_path(APP_DIR_SETTINGS), 'user.json')) and (ed.cmd(cmds.cmd_FileSave), ed.cmd(cmds.cmd_FileClose));
import tempfile, time; fpath = os.path.join(tempfile.gettempdir(), filename); t1 = time.time(); file_open(fpath); t2 = time.time(); print(f"file_open: {t2-t1:.4f}s");
```

file_open: 14.4858s

### 'scrollbar_themed': True
```python
filename="cuda_undo_test_rand_1M.txt";
import os, cudatext as app, cudatext_cmd as cmds, cudax_lib;
cudax_lib.set_opt('scrollbar_themed', True);
cudax_lib.set_opt('wrap_enabled_max_lines', 1100000); cudax_lib.set_opt('wrap_mode', 1); file_open(os.path.join(app_path(APP_DIR_SETTINGS), 'user.json')) and (ed.cmd(cmds.cmd_FileSave), ed.cmd(cmds.cmd_FileClose));
import tempfile, time; fpath = os.path.join(tempfile.gettempdir(), filename); t1 = time.time(); file_open(fpath); t2 = time.time(); print(f"file_open: {t2-t1:.4f}s");
```

file_open: 7.8775s
 
 
with this fix it takes 8s too
_____________________________________
ai reasoning:

## Why `scrollbar_themed:false` doubles `file_open` time

The two modes use **completely different scrollbar mechanisms** in `atsynedit.pas` (`UpdateScrollbarVert`, ~line 3248):

- `scrollbar_themed:true` → `OptScrollbarsNew=true` → custom `TATScrollbar` **child control** (app-painted)
- `scrollbar_themed:false` → `OptScrollbarsNew=false` → **OS-native scrollbar** (`ShowScrollBar()` / `SetScrollInfo()` on the editor window)

The timing difference is not the scrollbar itself — it's a **double word-wrap calculation**. Your 1M-line file is wrapped **twice** (7.88 × 2 ≈ 15.8 ≈ your 14.49s). The chain:

1. First paint after load → `DoPaintAll` → `DoPaintMain` → `UpdateWrapInfo` → **full wrap of 1M lines at client width W1** (no scrollbar yet, since the doc was empty when the tab was created → `Auto` scrollbar style = hidden).
2. At the *end* of `DoPaint`: `UpdateScrollbarVert` sees 1M lines → `ShowOsBarVert:=true` → `ShowScrollBar(Handle, SB_VERT, true)` → **the native scrollbar eats ~16px of the client area** → `GetClientSizes` (line 6007: `W:= inherited ClientWidth` in this mode) returns a smaller width → `RepaintNeeded`.
3. `PaintEx` immediately runs `DoPaint` a **second time** → `UpdateWrapInfo` detects `GetVisibleColumns()` changed → `bParamsChanged:=true` → **full re-wrap of all 1M lines at W2**.

Themed mode is immune because `GetClientSizes` **always reserves the scrollbar width** (`Dec(W, FScrollbarVert.Width)` — unconditionally, with the comment *"better check this instead of FScrollbarVert.Visible"*). The child control appearing doesn't change the wrap width, so the 2nd `UpdateWrapInfo` exits early ("nothing changed") and only one wrap runs.

## The fix

I wrote a minimal patch (21 lines, no deletions) in `TATSynEdit.UpdateWrapInfo`: for big documents, show the vertical **OS scrollbar *before* the wrap calculation** starts, so the wrap uses the final client width and never gets invalidated:


```
if (not FOptScrollbarsNew) and
  (not ShowOsBarVert) and
  (not ModeOneLine) and
  (FOptScrollStyleVert<>TATEditorScrollbarStyle.Hide) and
  (FWrapMode<>TATEditorWrapMode.ModeOff) and
  (Strings.Count>GetVisibleLines) then
begin
  ShowOsBarVert:= true;
  UpdateInitialVars(Canvas); //refresh FClientW/H + FRect* for reduced client area
end;
```

Patching `UpdateWrapInfo` itself covers **all** wrap entry points (first paint, `SetWrapMode`, history-restore `SetLineTop`), not just `file_open`. Known remaining edge (same as before the patch, unavoidable with native bars): if a document shrinks during editing until the `Auto` scrollbar disappears, one re-wrap occurs — but that's a small/cheap doc by then.


