### PR TITLE
Final optimization fixes

### DIFF
--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -554,6 +554,14 @@ var
   SPunct: UnicodeString;
 begin
   SPunct:= ATEditorOptions.PunctuationToWrapWithWords;
+  //2026.09.12 (CudaText perf): pointer equality of the same string instance
+  //(editors pass their constant FOptNonWordChars; the stored keys hold
+  //references, so a stored key's address cannot be reused by another string)
+  //skips the full content comparison, which ran for every wrapped line part
+  if WrapWordTableValid and
+    (Pointer(WrapWordKeyNonChars)=Pointer(ANonWordChars)) and
+    (Pointer(WrapWordKeyPunct)=Pointer(SPunct)) then
+    Exit;
   if WrapWordTableValid and
     (WrapWordKeyNonChars=ANonWordChars) and
     (WrapWordKeyPunct=SPunct) then
@@ -659,12 +667,19 @@ begin
     while i<ALen do
     begin
       ch:= P[i];
-      NClass:= FixedSizes[Ord(ch)];
-      if (NClass<>uw_normal) and
-        ((NClass<>uw_space) or (ch=#9)) then
+      //2026.09.12 (CudaText perf): printable ASCII (space..tilde) is always
+      //of fixed 1-column width (uw_normal, and space is non-tab uw_space),
+      //so the FixedSizes lookup is only needed for other chars; this halved
+      //the scan time of the word-wrap calc for hex/base64-like corpora
+      if (ch<#32) or (ch>#126) then
       begin
-        bAllWidth:= false;
-        Break;
+        NClass:= FixedSizes[Ord(ch)];
+        if (NClass<>uw_normal) and
+          ((NClass<>uw_space) or (ch=#9)) then
+        begin
+          bAllWidth:= false;
+          Break;
+        end;
       end;
       if not WrapWordChar(ch) then
         bAllWordChars:= false;

--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -401,9 +401,12 @@ begin
   end;
 end;
 
-function IsCharSpace(ch: widechar): boolean;
+function IsCharSpace(ch: widechar): boolean; inline;
 begin
-  Result:= IsCharUnicodeSpace(ch);
+  //2026.09.11 (CudaText perf): inlined body of IsCharUnicodeSpace() (same
+  //FixedSizes lookup, no cross-unit call): this function is called per char
+  //in the word-wrap scan of SGetIndentCharsBuf()/FindWordWrapOffsetBuf()
+  Result:= FixedSizes[Ord(ch)]=uw_space;
 end;
 
 function IsCharSpace(ch: char): boolean;
@@ -423,7 +426,7 @@ begin
   Result:= Pos(ch, '.,;:''"/\-+*=()[]{}<>?!@#$%^&|~`')>0;
 end;
 
-function IsCharSurrogateAny(ch: widechar): boolean;
+function IsCharSurrogateAny(ch: widechar): boolean; inline;
 begin
   Result:= (ch>=#$D800) and (ch<=#$DFFF);
 end;
@@ -433,7 +436,7 @@ begin
   Result:= (ch>=#$D800) and (ch<=#$DBFF);
 end;
 
-function IsCharSurrogateLow(ch: widechar): boolean;
+function IsCharSurrogateLow(ch: widechar): boolean; inline;
 begin
   Result:= (ch>=#$DC00) and (ch<=#$DFFF);
 end;
@@ -606,20 +609,70 @@ var
   Offsets: TATIntFixedArray;
   ch: widechar;
   bWordCh, bWordNext: boolean;
+  i: SizeInt;
+  NClass: byte;
+  bCheckWidth, bAllWidth: boolean;
 begin
   if (P=nil) or (ALen=0) then
     Exit(0);
   if AColumns<ATEditorOptions.MinWordWrapOffset then
     Exit(AColumns);
 
-  CalcCharOffsetsBuf(ALineIndex, P, ALen, Offsets);
+  //2026.09.11 (CudaText perf): forward scan of the line part detects the
+  //frequent case when ALL chars have the fixed width of 1 column (100
+  //percents), i.e. CalcCharOffsetsBuf() would fill Offsets.Data[k]=(k+1)*100
+  //for them (exactly what it fills for parts longer than ATEditorMaxFixedArray).
+  //It happens for monospaced fonts (not FontProportional) when all chars are
+  //of FixedSizes classes uw_normal/uw_space, without tab-chars (checked by
+  //the scan below); for parts longer than ATEditorMaxFixedArray it's always so
+  //(CalcCharOffsetsBuf fills uniform values for them regardless of the font).
+  //Then the wrap candidates are calculated arithmetically, without building
+  //the 32Kb Offsets array per line part, which dominated the wrap calc time
+  //of big documents (CudaText test: 1M lines x 500 random hex chars).
+  //Mixed parts (with tabs/CJK/fullwidth chars) and proportional fonts fall
+  //back to the original code, results are identical in all cases.
+  bCheckWidth:= (not FontProportional) and (ALen<=ATEditorMaxFixedArray);
+  bAllWidth:= (ALen>ATEditorMaxFixedArray);
 
-  if Offsets.Data[Offsets.Len-1]<=AColumns*100 then
-    Exit(ALen);
+  if bCheckWidth then
+  begin
+    i:= 0;
+    while i<ALen do
+    begin
+      ch:= P[i];
+      NClass:= FixedSizes[Ord(ch)];
+      if (NClass<>uw_normal) and
+        ((NClass<>uw_space) or (ch=#9)) then
+      begin
+        bAllWidth:= false;
+        Break;
+      end;
+      Inc(i);
+    end;
+  end;
 
-  //NAvg is average wrap offset, we use it if no correct offset found
-  N:= Min(ALen, ATEditorMaxFixedArray)-1;
-  while (N>0) and (Offsets.Data[N]>(AColumns+1)*100) do Dec(N);
+  if bAllWidth then
+  begin
+    //offsets of the whole part are (k+1)*100
+    if Min(ALen, ATEditorMaxFixedArray)<=AColumns then
+      Exit(ALen);
+    //NAvg is average wrap offset, we use it if no correct offset found
+    N:= Min(ALen, ATEditorMaxFixedArray)-1;
+    if N>AColumns then
+      N:= SizeInt(AColumns); //AColumns<N<=ATEditorMaxFixedArray here, fits SizeInt
+  end
+  else
+  begin
+    CalcCharOffsetsBuf(ALineIndex, P, ALen, Offsets);
+
+    if Offsets.Data[Offsets.Len-1]<=AColumns*100 then
+      Exit(ALen);
+
+    //NAvg is average wrap offset, we use it if no correct offset found
+    N:= Min(ALen, ATEditorMaxFixedArray)-1;
+    while (N>0) and (Offsets.Data[N]>(AColumns+1)*100) do Dec(N);
+  end;
+
   NAvg:= N;
   if NAvg<ATEditorOptions.MinWordWrapOffset then
     Exit(ATEditorOptions.MinWordWrapOffset);
@@ -630,21 +683,22 @@ begin
   //indexed S[N] (each indexed read of UnicodeString is a runtime helper call
   //with range check); classification of a char is done once and reused on
   //the next loop iteration (as classification of the previous char)
-  WrapWordTableBuild(ANonWordChars);
+  //2026.09.11: test of 2 word-chars is placed first (2 cached booleans,
+  //cheaper than IsCharSurrogateLow/IsCharCJKText calls), operands are pure
+  //so the order gives identical results
   //0-based pointer access: S[i] = P[i-1]; initial N is in 1..Length(S)-1,
   //loop keeps N>=1 (Break when N<=NMin, NMin>=1)
+  WrapWordTableBuild(ANonWordChars);
   if N>=1 then
     bWordCh:= WrapWordChar(P[N-1]) //class of S[N]
   else
     bWordCh:= false;
   bWordNext:= WrapWordChar(P[N]); //class of S[N+1]
   repeat
-    ch:= P[N-1]; //S[N]
-
     if (N>NMin) and
-     (IsCharSurrogateLow(P[N]) or //don't wrap inside surrogate pair: S[N+1]
-      (IsCharCJKText(ch) and IsCharCJKPunctuation(P[N])) or //don't wrap between CJK char and CJK punctuation
-      (bWordCh and bWordNext) or //don't wrap between 2 word-chars
+     ((bWordCh and bWordNext) or //don't wrap between 2 word-chars
+      IsCharSurrogateLow(P[N]) or //don't wrap inside surrogate pair: S[N+1]
+      (IsCharCJKText(P[N-1]) and IsCharCJKPunctuation(P[N])) or //don't wrap between CJK char and CJK punctuation
       (AWrapIndented and IsCharSpace(P[N])) //space as 2nd char looks bad with Python sources
      )
     then

--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -196,6 +196,15 @@ type
       const ANonWordChars: atString; AWrapIndented: boolean): integer;
     function FindWordWrapOffsetBuf(ALineIndex: integer; P: PatChar; ALen: SizeInt; AColumns: Int64;
       const ANonWordChars: atString; AWrapIndented: boolean): integer;
+    //2026.09.12 (CudaText perf): raw-ASCII fast path of FindWordWrapOffsetBuf:
+    //P points to the raw ANSI bytes of an ASCII-stored line part (TATStrings
+    //items with Ex.Wide=false never contain bytes >=128), no WideChar
+    //conversion buffer is needed. Returns the same value as
+    //FindWordWrapOffsetBuf would return for the zero-extended buffer, or -1
+    //when the part is not pure printable ASCII (tab/control/8-bit byte):
+    //caller must then use the PWideChar version
+    function FindWordWrapOffsetBytes(P: PByte; ALen: SizeInt; AColumns: Int64;
+      const ANonWordChars: atString; AWrapIndented: boolean): integer;
     function FindClickedPosition(ALineIndex: integer;
       const Str: atString;
       const StrLen: SizeInt;
@@ -761,6 +770,108 @@ begin
     Result:= NAvg;
 end;
 
+function TATStringTabHelper.FindWordWrapOffsetBytes(P: PByte; ALen: SizeInt; AColumns: Int64;
+  const ANonWordChars: atString; AWrapIndented: boolean): integer;
+{
+2026.09.12 (CudaText perf): raw-ASCII variant of FindWordWrapOffsetBuf for
+the word-wrap calculation (ATWrapInfo_CalcLine). It works on the raw ANSI
+bytes of ASCII-stored TATStrings items (Ex.Wide=false: all bytes <128), so
+the per-part byte-to-WideChar conversion (TATStringItem.LineSubBuf, ~0.2s
+per 1M lines x 500 chars on the reference machine) is skipped entirely, and
+the scan reads 1 byte per char instead of 2.
+
+Behavior: returns the same offset as FindWordWrapOffsetBuf would give for
+the zero-extended WideChar buffer, or -1 if the part contains a byte outside
+#printable-ASCII #32..#126 (tab, control char, or -defensively- a byte >=128,
+which cannot occur in ASCII-stored items): caller falls back to the PWideChar
+version then. For bytes in #32..#126:
+- all are of fixed 1-column width (uw_normal, and #32 is non-tab uw_space),
+  exactly what the width scan of FindWordWrapOffsetBuf verifies;
+- surrogate/CJK conditions of the backward scan are never true, so only the
+  word-glue test and the wrap-indented space test remain;
+- IsCharSpace() is true only for #32 (FixedSizes: #9/#32/#A0.. are uw_space,
+  of which only #32 is in the accepted byte range), so the indent scan counts
+  leading #32 bytes, like SGetIndentCharsBuf does for the wide buffer.
+}
+var
+  N, NMin, NAvg: SizeInt;
+  b: byte;
+  bWordCh, bWordNext, bAllWordChars: boolean;
+  i: SizeInt;
+begin
+  Result:= -1;
+  if (P=nil) or (ALen=0) then
+    Exit(0);
+  if AColumns<ATEditorOptions.MinWordWrapOffset then
+    Exit(AColumns);
+
+  WrapWordTableBuild(ANonWordChars);
+
+  //one scan: verify all bytes are printable ASCII (else -1 = fallback;
+  //such bytes are all of fixed 1-column width), and detect the all-word-chars
+  //case (to skip the backward scan)
+  bAllWordChars:= true;
+  i:= 0;
+  while i<ALen do
+  begin
+    b:= P[i];
+    if (b<32) or (b>126) then
+      Exit(-1);
+    if not WrapWordTable[b] then
+      bAllWordChars:= false;
+    Inc(i);
+  end;
+
+  //offsets of the whole part are (k+1)*1
+  if Min(ALen, ATEditorMaxFixedArray)<=AColumns then
+    Exit(ALen);
+
+  N:= Min(ALen, ATEditorMaxFixedArray)-1;
+  if N>AColumns then
+    N:= SizeInt(AColumns);
+
+  NAvg:= N;
+  if NAvg<ATEditorOptions.MinWordWrapOffset then
+    Exit(ATEditorOptions.MinWordWrapOffset);
+
+  if bAllWordChars then
+    Exit(NAvg);
+
+  //indent chars of the part: leading #32 bytes (see comment above)
+  NMin:= 0;
+  while (NMin<ALen) and (P[NMin]=32) do
+    Inc(NMin);
+  Inc(NMin);
+
+  //backward word-boundary scan, byte version: only the word-glue test and
+  //the wrap-indented space test apply (surrogate/CJK are impossible here);
+  //0-based access: P[i] = wide-buffer P[i]
+  if N>=1 then
+    bWordCh:= WrapWordTable[P[N-1]]
+  else
+    bWordCh:= false;
+  bWordNext:= WrapWordTable[P[N]];
+  repeat
+    if (N>NMin) and
+     ((bWordCh and bWordNext) or //don't wrap between 2 word-chars
+      (AWrapIndented and (P[N]=32)) //space as 2nd char looks bad with Python sources
+     )
+    then
+    begin
+      Dec(N);
+      bWordNext:= bWordCh;
+      bWordCh:= WrapWordTable[P[N-1]]; //N>=1 here
+    end
+    else
+      Break;
+  until false;
+
+  if N>NMin then
+    Result:= N
+  else
+    Result:= NAvg;
+end;
+
 function SGetIndentChars(const S: string): SizeInt;
 var
   P: PChar;
@@ -1175,10 +1286,47 @@ begin
 end;
 
 function SStringHasEol(const S: string): boolean;
+{
+2026.09.12 (CudaText perf): word-at-a-time scan - 8 bytes per iteration instead
+of two Pos() calls (two full passes over the line). Same result: any byte
+#10 or #13. It's called per line by TATStrings.TextReplaceLines_UTF8 (the
+parse loop of CudaText's ed.replace_lines: 1M lines x 500 chars gave
+~0.4s in the user's callgrind for the two Pos passes).
+}
+var
+  P: PByte;
+  NLen: SizeInt;
+  Q, X: QWord;
 begin
-  Result:=
-    (Pos(#10, S)>0) or
-    (Pos(#13, S)>0);
+  NLen:= Length(S);
+  if NLen=0 then exit(false);
+  P:= Pointer(S);
+  //leading unaligned bytes: per-byte
+  while (NLen>0) and ((PtrUInt(P) and 7)<>0) do
+  begin
+    if (P^=10) or (P^=13) then exit(true);
+    Inc(P);
+    Dec(NLen);
+  end;
+  //main part: 8 bytes per iteration, SWAR zero-byte detection for both #10 and #13
+  while NLen>=8 do
+  begin
+    Q:= PQWord(P)^;
+    X:= Q xor QWord($0A0A0A0A0A0A0A0A);
+    if (((X-QWord($0101010101010101)) and (not X) and QWord($8080808080808080))<>0) then exit(true);
+    X:= Q xor QWord($0D0D0D0D0D0D0D0D);
+    if (((X-QWord($0101010101010101)) and (not X) and QWord($8080808080808080))<>0) then exit(true);
+    Inc(P, 8);
+    Dec(NLen, 8);
+  end;
+  //tail: per-byte
+  while NLen>0 do
+  begin
+    if (P^=10) or (P^=13) then exit(true);
+    Inc(P);
+    Dec(NLen);
+  end;
+  Result:= false;
 end;
 
 function TATStringTabHelper.SpacesToTabs(ALineIndex: integer; const S: atString): atString;

--- a/atsynedit/atstringproc.pas
+++ b/atsynedit/atstringproc.pas
@@ -611,7 +611,7 @@ var
   bWordCh, bWordNext: boolean;
   i: SizeInt;
   NClass: byte;
-  bCheckWidth, bAllWidth: boolean;
+  bCheckWidth, bAllWidth, bAllWordChars: boolean;
 begin
   if (P=nil) or (ALen=0) then
     Exit(0);
@@ -631,11 +631,30 @@ begin
   //of big documents (CudaText test: 1M lines x 500 random hex chars).
   //Mixed parts (with tabs/CJK/fullwidth chars) and proportional fonts fall
   //back to the original code, results are identical in all cases.
+  //
+  //2026.09.12 fix (CudaText perf): the scan MUST set bAllWidth:=true on
+  //success. It was initialized to (ALen>ATEditorMaxFixedArray), which is
+  //false for all parts <=4096 chars, and the scan below only assigned
+  //false - so the arithmetic path was DEAD CODE for every part of the wrap
+  //calc (parts are capped by NPartCap<=2048 chars), and CalcCharOffsetsBuf
+  //still built the 32Kb Offsets array for every line part. Profile of
+  //CudaText set_text_all (1M lines x 500 hex chars, wrap on): UPDATEWRAPINFO
+  //18.0s, of which CALCCHAROFFSETSBUF 10.1s - all of it avoidable by the
+  //already-verified arithmetic path.
+  //The scan also detects parts consisting entirely of word-chars (no
+  //spaces/punctuation-mix/CJK): for such parts the backward word-boundary
+  //scan below provably ends at N<=NMin and returns NAvg, so it is skipped
+  //(typical for hex/base64/URL-like corpora without any spaces).
   bCheckWidth:= (not FontProportional) and (ALen<=ATEditorMaxFixedArray);
   bAllWidth:= (ALen>ATEditorMaxFixedArray);
+  bAllWordChars:= false;
+
+  WrapWordTableBuild(ANonWordChars);
 
   if bCheckWidth then
   begin
+    bAllWidth:= true;
+    bAllWordChars:= true;
     i:= 0;
     while i<ALen do
     begin
@@ -647,8 +666,12 @@ begin
         bAllWidth:= false;
         Break;
       end;
+      if not WrapWordChar(ch) then
+        bAllWordChars:= false;
       Inc(i);
     end;
+    if not bAllWidth then
+      bAllWordChars:= false; //scan stopped early: word-char info is partial
   end;
 
   if bAllWidth then
@@ -677,6 +700,13 @@ begin
   if NAvg<ATEditorOptions.MinWordWrapOffset then
     Exit(ATEditorOptions.MinWordWrapOffset);
 
+  //2026.09.12 (CudaText perf): if all chars of the part are word-chars,
+  //then every position of the backward scan below satisfies its first
+  //continue-condition (bWordCh and bWordNext), so the scan always runs
+  //down to N<=NMin and the result is NAvg - skip it entirely
+  if bAllWordChars then
+    Exit(NAvg);
+
   NMin:= SGetIndentCharsBuf(P, ALen)+1;
 
   //2026.09: optimized scan (CudaText perf): PWideChar access instead of
@@ -688,7 +718,6 @@ begin
   //so the order gives identical results
   //0-based pointer access: S[i] = P[i-1]; initial N is in 1..Length(S)-1,
   //loop keeps N>=1 (Break when N<=NMin, NMin>=1)
-  WrapWordTableBuild(ANonWordChars);
   if N>=1 then
     bWordCh:= WrapWordChar(P[N-1]) //class of S[N]
   else

--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -169,6 +169,11 @@ type
     function HasAsciiNoTabs: boolean;
     procedure Init(const S: string; AEnd: TATLineEnds; AllowBadCharsOfLen1: boolean);
     procedure Init(const S: UnicodeString; AEnd: TATLineEnds);
+    //2026.09.11 (CudaText perf): Init() for a line which the caller has already
+    //checked to be pure ASCII (byte<128), it skips the IsStringWithUnicode()
+    //re-scan in SetLineA(); used by the loading code, which scans buffer bytes
+    //for EOL chars anyway
+    procedure InitAscii(const S: string; AEnd: TATLineEnds);
     procedure LineStateToChanged;
     procedure LineStateToSaved; inline;
     procedure LineStateToNone; inline;
@@ -341,6 +346,12 @@ type
     procedure SetLineState(AIndex: SizeInt; AValue: TATLineState);
     procedure SetLineUpdated(AIndex: SizeInt; AValue: boolean);
     procedure DoLoadFromStream(Stream: TStream; AOptions: TATLoadStreamOptions; out AForcedToANSI: boolean);
+    //2026.09.11 (CudaText perf): the buffer-parsing core split from DoLoadFromStream:
+    //line scanning + items creation + UTF8-to-ANSI fallback + progress events.
+    //Lets LoadFromString() parse the string data in-place, without copying the
+    //whole text into TMemoryStream + GetMem buffer (2x memcpy of the full text)
+    procedure ParseBuffer(ABuf: PAnsiChar; ABufSize, AStreamSize: Int64; ACharSize: SizeInt;
+      AOptions: TATLoadStreamOptions; AFirePreProgress: boolean; out AForcedToANSI: boolean);
     procedure DoDetectEndings;
     procedure DoFinalizeLoading;
     procedure ClearLineStates(ASaved: boolean; AFrom: SizeInt=-1; ATo: SizeInt=-1);
@@ -400,6 +411,11 @@ type
     function IsPosFolded(AX, AY, AIndexClient: SizeInt): boolean;
     function IsSizeBig(const ALimit: SizeInt): boolean;
     procedure LineAddRaw_NoUndo(const S: string; AEnd: TATLineEnds; AllowBadCharsOfLen1: boolean);
+    //2026.09.11 (CudaText perf): LineAddRaw_NoUndo() for a line which the caller
+    //has already checked to be pure ASCII (byte<128): skips the
+    //IsStringWithUnicode() re-scan, which was a notable cost when loading
+    //big ASCII files (a full extra pass over all buffer bytes)
+    procedure LineAddRaw_NoUndoAscii(const S: string; AEnd: TATLineEnds);
     procedure LineAddRaw_NoUndo(const S: UnicodeString; AEnd: TATLineEnds);
     procedure LineAddRaw(const AString: atString; AEnd: TATLineEnds; AWithEvent: boolean=true);
     procedure LineAdd(const AString: atString);
@@ -900,6 +916,35 @@ procedure TATStringItem.Init(const S: UnicodeString; AEnd: TATLineEnds);
 begin
   FillChar(Ex, SizeOf(Ex), 0);
   SetLineW(S);
+
+  Ex.Ends:= TATBits2(AEnd);
+  Ex.State:= TATBits2(TATLineState.Added);
+  Ex.Updated:= true;
+end;
+
+procedure TATStringItem.InitAscii(const S: string; AEnd: TATLineEnds);
+//2026.09.11 (CudaText perf): same as Init(S, AEnd, false) minus the
+//IsStringWithUnicode() scan: caller guarantees all bytes of S are <128
+//(the loading EOL scan checks buffer bytes for it), so SetLineA() takes
+//the non-Wide 'Buf:=S' branch anyway. Skips one full extra pass over
+//all chars of loaded files.
+var
+  NLen: SizeInt;
+begin
+  FillChar(Ex, SizeOf(Ex), 0);
+
+  //SetLineA(S, false) with the known-pure-ASCII shortcut
+  LineStateToChanged;
+  Ex.HasTab:= 0; //cFlagUnknown
+  Ex.HasAsciiNoTabs:= 0; //cFlagUnknown
+  Ex.Updated:= true;
+
+  NLen:= Length(S);
+  if NLen>=MaxInt-1 then
+    raise EEditorTooLongLine.Create('Storing too long line: 0x'+IntToHex(NLen, 8));
+
+  Ex.Wide:= false;
+  Buf:= S;
 
   Ex.Ends:= TATBits2(AEnd);
   Ex.State:= TATBits2(TATLineState.Added);
@@ -4241,6 +4286,18 @@ var
   Item: TATStringItem;
 begin
   Item.Init(S, AEnd);
+  Item.Ex.State:= TATBits2(TATLineState.Added);
+  FList.Add(@Item);
+  FillChar(Item, SizeOf(Item), 0);
+end;
+
+procedure TATStrings.LineAddRaw_NoUndoAscii(const S: string; AEnd: TATLineEnds);
+//2026.09.11 (CudaText perf): LineAddRaw_NoUndo() for a caller-checked
+//pure-ASCII line, see TATStringItem.InitAscii
+var
+  Item: TATStringItem;
+begin
+  Item.InitAscii(S, AEnd);
   Item.Ex.State:= TATBits2(TATLineState.Added);
   FList.Add(@Item);
   FillChar(Item, SizeOf(Item), 0);

--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -393,9 +393,15 @@ type
     //for pure-ASCII lines) and undo-item's carets/markers/attribs arrays are
     //passed by caller (captured once for the whole block-insert loop)
     procedure LineInsertToSlotUtf8(AIndexForUndoItem, AIndexForLine: SizeInt; const AString: string;
+      AEnd: TATLineEnds;
       const ACarets, ACarets2: TATPointPairArray;
       const AMarkers, AMarkers2: TATMarkerMarkerArray;
       const AAttribs: TATMarkerAttribArray);
+    //2026.09.12 (CudaText perf): slot-fill part of LineInsertToSlotUtf8,
+    //WITHOUT the undo-item creation - used by LineBlockInsertEnds, which
+    //creates all placeholder undo-items with one TATUndoList.AddInsertRun()
+    //call before the fill loop
+    procedure LineFillSlotUtf8(AIndexForLine: SizeInt; const AString: string; AEnd: TATLineEnds);
   public
     CaretsAfterLastEdition: TATPointPairArray;
     EditingActive: boolean;
@@ -445,11 +451,27 @@ type
     //2026.09 (CudaText perf): copies a line part into a raw WideChar buffer
     //(caller-provided, no UnicodeString allocation/refcount), returns copied char count
     function LineSubBuf(ALineIndex, APosFrom, ALen: SizeInt; ADest: PWideChar): SizeInt;
+    //2026.09.12 (CudaText perf): direct read access to the raw ANSI buffer
+    //of an ASCII-stored line (Ex.Wide=false: all bytes <128, chars=bytes),
+    //for the word-wrap calculation's raw-byte fast path (ATWrapInfo_CalcLine
+    //-> FindWordWrapOffsetBytes): skips the per-part byte-to-WideChar
+    //conversion. Returns False for wide-stored lines (P=nil, NLen=0).
+    //Valid until the next modification of TATStrings (the wrap calc makes none)
+    function LineBytesPtr(ALineIndex: SizeInt; out P: PByte; out NLen: SizeInt): boolean;
     function LineCharAt(ALineIndex, ACharIndex: SizeInt): WideChar;
     procedure GetIndentProp(ALineIndex: SizeInt; out ACharCount: SizeInt; out AKind: TATLineIndentKind);
     function LineLenWithoutSpace(ALineIndex: SizeInt): SizeInt;
     procedure LineBlockDelete(ALine1, ALine2: SizeInt; AForceLast: boolean = true);
     procedure LineBlockInsert(ALineFrom: SizeInt; ANewLines: TStringList);
+    //2026.09.12 (CudaText perf): like LineBlockInsert, but lines are created
+    //with their final line-endings (AEnds[k], None = document's Endings), so
+    //the caller's LinesEnds[] fixup loop becomes a no-op - TextReplaceLines_
+    //UTF8 made a ChangeEol undo-item per line when the parsed endings differed
+    //from Endings (~1.3s per 1M lines). Undo-items are identical (one Insert
+    //placeholder per line), no ChangeEol items are needed: undoing deletes the
+    //lines wholesale (mirror-items capture final text+endings at undo time)
+    procedure LineBlockInsertEnds(ALineFrom: SizeInt; ANewLines: TStringList;
+      const AEnds: array of TATLineEnds);
     function ColumnPosToCharPos(AIndex: SizeInt; AX: SizeInt; ATabHelper: TATStringTabHelper): SizeInt;
     function CharPosToColumnPos(AIndex: SizeInt; AX: SizeInt; ATabHelper: TATStringTabHelper): SizeInt;
     function GetItemPtr(AIndex: SizeInt): PATStringItem;
@@ -1853,12 +1875,13 @@ begin
 end;
 
 procedure TATStrings.LineInsertToSlotUtf8(AIndexForUndoItem, AIndexForLine: SizeInt; const AString: string;
+  AEnd: TATLineEnds;
   const ACarets, ACarets2: TATPointPairArray;
   const AMarkers, AMarkers2: TATMarkerMarkerArray;
   const AAttribs: TATMarkerAttribArray);
 {
 2026.09 (CudaText perf): variant of LineInsertToSlot() for LineBlockInsert's
-fast path. Two changes (undo-items and document content are the same as
+fast path. Changes (undo-items and document content are the same as
 LineInsertToSlot gives):
 - input string is UTF8, like the caller's TStringList items: pure-ASCII lines
   (IsStringWithUnicode=false) skip UTF8Decode+SetLineW and go to
@@ -1868,6 +1891,12 @@ LineInsertToSlot gives):
 - carets/markers/attribs arrays are captured once for the whole
   block-insert loop (the loop fires no events, so they are the same for every
   line) and passed to AddUndoItemEx(), like LineBlockDelete() does.
+2026.09.12 (CudaText perf): AEnd param - the line's FINAL line-ending is set
+//by Init() directly (was: FEndings + caller's per-line LinesEnds[] fixup,
+//which made a ChangeEol undo-item per line when endings differed).
+//Item state is identical: Init sets Ends:=AEnd, State:=Added, Updated:=true;
+//the old fixup's SetLineEnd changed Ends and called LineStateToChanged()
+//(no-op for Added lines, see #2617) + Updated:=true - same visible state.
 }
 var
   Item: PATStringItem;
@@ -1879,9 +1908,26 @@ begin
   Item:= FList.GetItem(AIndexForLine);
   if not IsStringWithUnicode(AString) then
     //pure ASCII: direct store, no UTF8Decode/UnicodeString round-trip
-    Item^.Init(AString, FEndings, false{AllowBadCharsOfLen1})
+    Item^.Init(AString, AEnd, false{AllowBadCharsOfLen1})
   else
-    Item^.Init(UTF8Decode(AString), FEndings);
+    Item^.Init(UTF8Decode(AString), AEnd);
+end;
+
+procedure TATStrings.LineFillSlotUtf8(AIndexForLine: SizeInt; const AString: string; AEnd: TATLineEnds);
+//2026.09.12 (CudaText perf): the fill part of LineInsertToSlotUtf8 (without
+//AddUndoItemEx): UpdateModified + GetItem + Init with the final line-ending.
+//The undo-items for the whole block are created in advance by
+//LineBlockInsertEnds via TATUndoList.AddInsertRun()
+var
+  Item: PATStringItem;
+begin
+  UpdateModified;
+  Item:= FList.GetItem(AIndexForLine);
+  if not IsStringWithUnicode(AString) then
+    //pure ASCII: direct store, no UTF8Decode/UnicodeString round-trip
+    Item^.Init(AString, AEnd, false{AllowBadCharsOfLen1})
+  else
+    Item^.Init(UTF8Decode(AString), AEnd);
 end;
 
 procedure TATStrings.LineInsertEx(ALineIndex: SizeInt; const AString: atString; AEnd: TATLineEnds;
@@ -2076,6 +2122,23 @@ begin
   if (ALen=0) or (ADest=nil) then exit(0);
   Item:= GetItemPtr(ALineIndex);
   Result:= Item^.LineSubBuf(APosFrom, ALen, ADest);
+end;
+
+function TATStrings.LineBytesPtr(ALineIndex: SizeInt; out P: PByte; out NLen: SizeInt): boolean;
+//2026.09.12 (CudaText perf): see the interface comment. LineSubLen is not
+//needed: for ASCII-stored items chars=bytes, so the buffer length IS the
+//line length
+var
+  ItemPtr: PATStringItem;
+begin
+  P:= nil;
+  NLen:= 0;
+  if not IsIndexValid(ALineIndex) then exit(false);
+  ItemPtr:= FList.GetItem(ALineIndex);
+  if ItemPtr^.Ex.Wide then exit(false);
+  P:= Pointer(ItemPtr^.Buf);
+  NLen:= Length(ItemPtr^.Buf);
+  Result:= P<>nil;
 end;
 
 function TATStrings.LineCharAt(ALineIndex, ACharIndex: SizeInt): WideChar;

--- a/atsynedit/atstrings.pas
+++ b/atsynedit/atstrings.pas
@@ -966,7 +966,7 @@ function TATStringItem.LineSubBuf(AFrom, ALen: SizeInt; ADest: PWideChar): SizeI
 //For non-wide (ASCII) items, bytes are zero-extended to WideChar, like
 //LineSub/CharAt do
 var
-  ResLen, i: SizeInt;
+  ResLen: SizeInt;
   Src: PChar;
   Dst: PWideChar;
 begin
@@ -974,20 +974,34 @@ begin
   if ADest=nil then exit;
   ResLen:= LineSubLen(AFrom, ALen);
   if ResLen=0 then exit;
+  Result:= ResLen;
   if Ex.Wide then
     Move(Buf[AFrom*2-1], ADest^, ResLen*2)
   else
   begin
+    //2026.09.11 (CudaText perf): zero-extension of bytes is unrolled by 4
+    //(same stores, but 4x less loop overhead); it's the per-line-part work
+    //of the word-wrap calculation for ASCII documents
     Src:= @Buf[AFrom];
     Dst:= ADest;
-    for i:= 1 to ResLen do
+    while ResLen>=4 do
     begin
-      Dst^:= WideChar(Ord(Src^));
+      Dst[0]:= WideChar(Ord(Src[0]));
+      Dst[1]:= WideChar(Ord(Src[1]));
+      Dst[2]:= WideChar(Ord(Src[2]));
+      Dst[3]:= WideChar(Ord(Src[3]));
+      Inc(Src, 4);
+      Inc(Dst, 4);
+      Dec(ResLen, 4);
+    end;
+    while ResLen>0 do
+    begin
+      Dst[0]:= WideChar(Ord(Src[0]));
       Inc(Src);
       Inc(Dst);
+      Dec(ResLen);
     end;
   end;
-  Result:= ResLen;
 end;
 
 function TATStringItem.CharAt(AIndex: SizeInt): WideChar;

--- a/atsynedit/atstrings_editing.inc
+++ b/atsynedit/atstrings_editing.inc
@@ -172,7 +172,14 @@ begin
       (EndsArray[High(EndsArray)]<>TATLineEnds.None);
 
     LineBlockDelete(ALineFrom, Min(ALineTo, Count-1)); //too big ALineTo allowed
-    LineBlockInsert(ALineFrom, ANewLines);
+    //2026.09.12 (CudaText perf): per-line line-endings are applied at the
+    //insert (lines are created with their FINAL endings), so the LinesEnds[]
+    //fixup loop below becomes a no-op for the fast path - it made a ChangeEol
+    //undo-item per line when the parsed endings differed from Endings
+    //(CudaText ed.replace_lines on Windows: new file has CRLF, Python lines
+    //end with LF -> 1M redundant ChangeEol items, ~1.3s per 1M lines).
+    //The slow per-line path (readonly/one-line/single line) still needs it.
+    LineBlockInsertEnds(ALineFrom, ANewLines, EndsArray);
 
     //set line-endings of inserted lines, except doc's last line;
     //items w/o explicit EOL give default Endings
@@ -769,9 +776,33 @@ begin
 end;
 
 procedure TATStrings.LineBlockInsert(ALineFrom: SizeInt; ANewLines: TStringList);
+begin
+  //2026.09.12 (CudaText perf): old behavior kept as a thin wrapper - all
+  //inserted lines get Endings (no per-line endings passed)
+  LineBlockInsertEnds(ALineFrom, ANewLines, []);
+end;
+
+procedure TATStrings.LineBlockInsertEnds(ALineFrom: SizeInt; ANewLines: TStringList;
+  const AEnds: array of TATLineEnds);
+{
+2026.09.12 (CudaText perf): LineBlockInsert with per-line line-endings
+(AEnds[k], TATLineEnds.None = document's Endings, like TextReplaceLines_
+UTF8's EOL fixup loop maps). Lines are created with their FINAL endings, so
+the caller's LinesEnds[] fixup becomes a no-op: TextReplaceLines_UTF8 made
+a ChangeEol undo-item per line whenever the parsed endings differed from
+Endings (CudaText ed.replace_lines on Windows: new file has CRLF endings,
+Python lines end with LF -> 1M ChangeEol items, ~1.3s). Those items were
+redundant: undoing the block deletes the lines wholesale, and mirror-items
+capture the final text+endings at undo time, so redo is identical too.
+
+Also creates the Insert placeholder undo-items with ONE bulk
+TATUndoList.AddInsertRun() call instead of AddUndoItemEx() per line (same
+items, ~0.3s less per 1M lines).
+}
 var
   bFast: boolean;
-  i, NDone: SizeInt;
+  i, NDone, NUndoSaved: SizeInt;
+  CurEnd: TATLineEnds;
   CurCarets, CurCarets2: TATPointPairArray;
   CurMarkers, CurMarkers2: TATMarkerMarkerArray;
   CurAttribs: TATMarkerAttribArray;
@@ -818,9 +849,12 @@ begin
     captured per line) - like LineBlockDelete() does. Per-line capture made
     5 editor callbacks per line (OnGetCaretsArray allocates an array),
     ~0.9s of 1M-lines replace_lines in callgrind.
-    Also pre-reserve the undo-list capacity: without it, 1M items grew the
-    list with re-allocation+memory-move on every growth step
-    (~2.5s in callgrind: SetCapacity/Expand/CopyItem).
+    2026.09.12: all Insert placeholder undo-items are created with ONE
+    TATUndoList.AddInsertRun() call (same items as per-line AddUndoItemEx
+    made: one TATEditAction.Insert item per line, same index, empty text).
+    The per-line AddUndoItemEx also did (per line): FRedoList.Clear (no-op
+    after the first call), AddUpdatesAction (same flag write every call) -
+    both are done once here, with the same resulting state.
     }
     if FEnabledCaretsInUndo then
     begin
@@ -843,26 +877,57 @@ begin
       CurUndoList:= FRedoList
     else
       CurUndoList:= nil;
-    if (CurUndoList<>nil) and (ANewLines.Count>=1000) then
-      if CurUndoList.Capacity < CurUndoList.Count+ANewLines.Count then
-        CurUndoList.Capacity:= CurUndoList.Count+ANewLines.Count;
+
+    NUndoSaved:= 0;
+    if CurUndoList<>nil then
+    begin
+      //same per-line AddUndoItemEx() did, once:
+      if not FUndoList.Locked and not FRedoList.Locked then
+        FRedoList.Clear;
+      AddUpdatesAction(ALineFrom, TATEditAction.Insert);
+
+      //bulk undo-items (skipped when the per-item AddUndoItemEx would skip:
+      //nil lists / zero undo limit are handled by the FUndoLimit check;
+      //AddInsertRun checks Locked and MaxCount itself)
+      if (FUndoList<>nil) and (FRedoList<>nil) and (FUndoLimit<>0) then
+      begin
+        NUndoSaved:= CurUndoList.Count;
+        CurUndoList.AddInsertRun(ALineFrom, ANewLines.Count, FCommandCode,
+          CurCarets, CurCarets2, CurMarkers, CurMarkers2, CurAttribs);
+      end;
+    end;
 
     NDone:= 0;
     try
       for i:= 0 to ANewLines.Count-1 do
       begin
+        if i<=High(AEnds) then
+        begin
+          CurEnd:= AEnds[i];
+          if CurEnd=TATLineEnds.None then
+            CurEnd:= FEndings;
+        end
+        else
+          CurEnd:= FEndings;
         //undo-item index is ALineFrom for all lines (like old code made),
         //list-slot index grows
-        LineInsertToSlotUtf8(ALineFrom, ALineFrom+i, ANewLines[i],
-          CurCarets, CurCarets2, CurMarkers, CurMarkers2, CurAttribs);
+        LineFillSlotUtf8(ALineFrom+i, ANewLines[i], CurEnd);
         Inc(NDone);
       end;
     except
       //keep list consistent on exception: slots, which were not filled,
       //must be removed; already filled lines (and their undo-items) remain,
-      //like old per-line code would leave on exception
+      //like old per-line code would leave on exception. The bulk-created
+      //undo-items are trimmed to what per-line code would have made:
+      //(NDone+1) items (the item of the failing line was created before its
+      //Init in the per-line code)
       if NDone<ANewLines.Count then
+      begin
         FList.DeleteRange(ALineFrom+NDone, ALineFrom+ANewLines.Count-1);
+        if NUndoSaved>0 then
+          while CurUndoList.Count>NUndoSaved+NDone+1 do
+            CurUndoList.DeleteLast;
+      end;
       raise;
     end;
   end

--- a/atsynedit/atstrings_load.inc
+++ b/atsynedit/atstrings_load.inc
@@ -24,6 +24,31 @@ begin
 end;
 
 
+function IsWordWithEolChar(const Q: QWord): boolean; inline;
+{
+2026.09.11 (CudaText perf): SWAR test - does the 8-byte word contain char
+#10 or #13? Classic "zero byte" bit-trick (see haszero in Bit Twiddling
+Hacks; borrow-safe for all inputs) applied to the word XOR-ed with a
+broadcasted char. Used by the tight EOL scan in ParseBuffer/_FindNextEol
+for ANSI/UTF8 buffers: the previous per-byte 'if (p^=#10) or (p^=#13)'
+loop was the dominating cost of parsing big files (500MB file: ~1.4s of
+~3.9s total, Very Sleepy callgrind).
+}
+const
+  cOnes: QWord = $0101010101010101;
+  cHigh: QWord = $8080808080808080;
+  cCharLF: QWord = $0A0A0A0A0A0A0A0A;
+  cCharCR: QWord = $0D0D0D0D0D0D0D0D;
+var
+  T1, T2: QWord;
+begin
+  T1:= Q xor cCharLF;
+  T2:= Q xor cCharCR;
+  Result:= (((T1-cOnes) and (not T1) and cHigh) or
+            ((T2-cOnes) and (not T2) and cHigh))<>0;
+end;
+
+
 function DetectStreamUtf16NoBom(Stream: TStream; BufSizeWords: integer; out IsLE: boolean): boolean;
 var
   Buf: array[0..80] of word;
@@ -361,9 +386,8 @@ end;
 
 procedure TATStrings.LoadFromString(const AText: string);
 var
-  MS: TMemoryStream;
-  Str: UnicodeString;
   EncOld: TATFileEncoding;
+  Str: UnicodeString;
   i: integer;
 begin
   if ReadOnly then exit;
@@ -382,25 +406,39 @@ begin
   end
   else
   begin
-    MS:= TMemoryStream.Create;
+    {
+    2026.09.11 (CudaText perf): parse the string data in-place, without
+copying the whole text to TMemoryStream + GetMem buffer (that was 2x memcpy
+of the full text, ~1.2s for the 500MB CudaText test, and 1GB of extra peak
+memory). Events/progress/fallbacks run like in LoadFromStream(): the same
+ParseBuffer() core is called, wrapped in ClearUndo/FLoadingFromStream/
+DoFinalizeLoading exactly like LoadFromStream() does.
+    }
     EncOld:= Encoding;
+    ClearUndo(true);
+    FLoadingFromStream:= true;
     try
-      MS.Write(AText[1], Length(AText)*1);
-      MS.Position:= 0;
       try
         Encoding:= TATFileEncoding.UTF8;
         EncodingDetect:= false;
-        LoadFromStream(MS, [TATLoadStreamOption.FromUTF8]);
-
-        //fixing CudaText issue #4172
-        if not SEndsWithEol(AText) then
-          ActionDeleteFakeLineAndFinalEol;
+        ParseBuffer(@AText[1], Length(AText), Length(AText), 1,
+          [TATLoadStreamOption.FromUTF8],
+          true,
+          FLoadingForcedANSI);
       finally
-        Encoding:= EncOld;
-        ActionAddFakeLineIfNeeded;
+        //same position as LoadFromStream()'s finally: before the
+        //CudaText #4172 fix below, so its undo items (if UndoLimit>0)
+        //survive, like they did before
+        DoFinalizeLoading;
+        FLoadingFromStream:= false;
       end;
+
+      //fixing CudaText issue #4172
+      if not SEndsWithEol(AText) then
+        ActionDeleteFakeLineAndFinalEol;
     finally
-      FreeAndNil(MS);
+      Encoding:= EncOld;
+      ActionAddFakeLineIfNeeded;
     end;
   end;
 
@@ -422,18 +460,27 @@ now uses per-encoding tight scanning loops, which don't need per-char
 EOL classification (see the comment in _FindNextEol).
 }
 
-procedure TATStrings.DoLoadFromStream(Stream: TStream;
-  AOptions: TATLoadStreamOptions; out AForcedToANSI: boolean);
+procedure TATStrings.ParseBuffer(ABuf: PAnsiChar; ABufSize, AStreamSize: Int64;
+  ACharSize: SizeInt; AOptions: TATLoadStreamOptions; AFirePreProgress: boolean;
+  out AForcedToANSI: boolean);
+{
+2026.09.11 (CudaText perf): the parsing core, split from DoLoadFromStream()
+so that LoadFromString() can parse the string data directly (no 2x memcpy
+of the whole text via TMemoryStream + GetMem buffer, ~1.2s for the 500MB
+CudaText test + 1GB of extra peak memory). Behavior is identical to the
+previous inline code: same scans, same events/progress, same UTF8-to-ANSI
+fallback.
+}
 var
   Buf: PAnsiChar;
   BufSize: Int64;
   NStreamSize: Int64;
   CharSize: SizeInt;
-  NSignatureLen: SizeInt;
   //------
   procedure _FindNextEol(AFromPos: SizeInt;
     out AFoundPos: SizeInt;
-    out AEnding: TATLineEnds);
+    out AEnding: TATLineEnds;
+    out AWithHighBit: boolean);
   {
   2026.09: optimized scanning (CudaText perf: parsing of big files was
   dominated by per-char _GetBufferEnding() case-dispatch + 'mod' check,
@@ -444,15 +491,18 @@ var
   }
   const
     cScanChunk = 4096;
+    cHighBits: QWord = $8080808080808080;
   label
     FoundEol;
   var
     bCancel: boolean;
-    p, pLimit, pEnd: PAnsiChar;
+    p, pLimit, pEnd, pWordEnd: PAnsiChar;
     NNextProgress: Int64;
+    Q: QWord;
   begin
     AFoundPos:= AFromPos;
     AEnding:= TATLineEnds.None;
+    AWithHighBit:= false;
     if AFromPos>=BufSize then exit;
 
     NNextProgress:=
@@ -464,14 +514,55 @@ var
     case FEncoding of
       TATFileEncoding.ANSI,
       TATFileEncoding.UTF8:
+        {
+        2026.09.11: 8 bytes per iteration (SWAR, see IsWordWithEolChar):
+        ~4x faster than the per-byte loop, same detected position. The scan
+        also detects bytes >=128 (AWithHighBit) for the caller: replaces the
+        IsStringWithUnicode() re-scan of each added line. PQWord reads are
+        done only for 8-aligned pointers (leading bytes per-byte), like in
+        IsStringWithUnicode().
+        }
         repeat
           pLimit:= p+cScanChunk;
           if pLimit>pEnd then pLimit:= pEnd;
+
+          //leading bytes until 8-aligned: per-byte
+          while (p<pLimit) and ((PtrUInt(p) and 7)<>0) do
+          begin
+            if (p^=#10) or (p^=#13) then goto FoundEol;
+            if Byte(p^)>=128 then AWithHighBit:= true;
+            Inc(p);
+          end;
+
+          //main part: 8 bytes per iteration
+          while p+8<=pLimit do
+          begin
+            Q:= PQWord(p)^;
+            if IsWordWithEolChar(Q) then
+            begin
+              //locate the exact EOL byte (word is fully inside the buffer)
+              pWordEnd:= p+8;
+              while p<pWordEnd do
+              begin
+                if (p^=#10) or (p^=#13) then goto FoundEol;
+                if Byte(p^)>=128 then AWithHighBit:= true;
+                Inc(p);
+              end;
+              //EOL is guaranteed to be found above; if not, continue safely
+              Continue;
+            end;
+            if (Q and cHighBits)<>0 then AWithHighBit:= true;
+            Inc(p, 8);
+          end;
+
+          //tail: per-byte
           while p<pLimit do
           begin
             if (p^=#10) or (p^=#13) then goto FoundEol;
+            if Byte(p^)>=128 then AWithHighBit:= true;
             Inc(p);
           end;
+
           if p>=pEnd then Break;
           if (p^=#10) or (p^=#13) then goto FoundEol;
 
@@ -687,6 +778,7 @@ var
     Len, NStart, NEnd: SizeInt;
     LineEndDeltas: array[boolean] of SizeInt;
     LineEnd: TATLineEnds;
+    bWithHigh: boolean;
     SA, SUtf8: string;
     SWide: UnicodeString;
     SQuad: UCS4String;
@@ -700,7 +792,7 @@ var
     LineEndDeltas[true]:= CharSize*2;
 
     repeat
-      _FindNextEol(NStart, NEnd, LineEnd);
+      _FindNextEol(NStart, NEnd, LineEnd, bWithHigh);
       Len:= NEnd-NStart;
       if Len>=MaxInt-12 then
         raise EEditorTooLongLine.Create('Too big line length on reading: 0x'+IntToHex(Len, 8));
@@ -729,7 +821,13 @@ var
             begin
               //this now raises exception if UTF8 content is bad, it's needed
               SetString(SA, @Buf[NStart], Len);
-              LineAddRaw_NoUndo(SA, LineEnd, TATLoadStreamOption.AllowBadCharsOfLen1 in AOptions);
+              //2026.09.11: the EOL scan already knows if the line has bytes
+              //>=128; for pure-ASCII lines (majority of big files) skip the
+              //IsStringWithUnicode() re-scan in the item Init
+              if bWithHigh then
+                LineAddRaw_NoUndo(SA, LineEnd, TATLoadStreamOption.AllowBadCharsOfLen1 in AOptions)
+              else
+                LineAddRaw_NoUndoAscii(SA, LineEnd);
             end;
 
           TATFileEncoding.UTF16LE,
@@ -766,6 +864,67 @@ var
   end;
   //------
 var
+  bCancel: boolean;
+begin
+  AForcedToANSI:= false;
+
+  Buf:= ABuf;
+  BufSize:= ABufSize;
+  NStreamSize:= AStreamSize;
+  CharSize:= ACharSize;
+
+  //LoadFromFile/LoadFromString already call Clear
+  if Count>0 then
+    Clear(false{AWithEvent});
+
+  //show progress before the parse of a huge buffer;
+  //(for stream loading this event is fired by DoLoadFromStream, before the
+  //slow GetMem call; for string loading there is no GetMem)
+  if AFirePreProgress and (BufSize>50*1024*1024) then
+  begin
+    FProgressKind:= TATStringsProgressKind.None;
+    FProgressValue:= 0;
+    if Assigned(FOnProgress) then
+    begin
+      bCancel:= false;
+      FOnProgress(Self, bCancel);
+    end;
+  end;
+
+  try
+    try
+      _LoadItems;
+    except
+      on E: Exception do
+      begin
+        Clear;
+        if E is EEditorBadUTF8 then
+        begin
+          //failed to load text as UTF8, so load again as ANSI
+          AForcedToANSI:= true;
+          FEncoding:= TATFileEncoding.ANSI;
+          FEncodingCodepage:= ATEditorOptions.FallbackEncoding;
+          CharSize:= 1;
+          _LoadItems;
+        end
+        else
+          raise;
+      end;
+    end;
+  finally
+    FProgressValue:= 0;
+    FProgressKind:= TATStringsProgressKind.None;
+  end;
+end;
+
+procedure TATStrings.DoLoadFromStream(Stream: TStream;
+  AOptions: TATLoadStreamOptions; out AForcedToANSI: boolean);
+var
+  Buf: PAnsiChar;
+  BufSize: Int64;
+  NStreamSize: Int64;
+  CharSize: SizeInt;
+  NSignatureLen: SizeInt;
   bWithBom, bCancel: boolean;
 begin
   AForcedToANSI:= false;
@@ -855,29 +1014,11 @@ begin
     Stream.Position:= NSignatureLen;
     Stream.ReadBuffer(Buf^, BufSize);
 
-    try
-      _LoadItems;
-    except
-      on E: Exception do
-      begin
-        Clear;
-        if E is EEditorBadUTF8 then
-        begin
-          //failed to load text as UTF8, so load again as ANSI
-          AForcedToANSI:= true;
-          FEncoding:= TATFileEncoding.ANSI;
-          FEncodingCodepage:= ATEditorOptions.FallbackEncoding;
-          CharSize:= 1;
-          _LoadItems;
-        end
-        else
-          raise;
-      end;
-    end;
+    //2026.09.11: parsing core (was inline here) moved to ParseBuffer(),
+    //shared with LoadFromString()
+    ParseBuffer(Buf, BufSize, NStreamSize, CharSize, AOptions, false, AForcedToANSI);
   finally
     FreeMem(Buf);
-    FProgressValue:= 0;
-    FProgressKind:= TATStringsProgressKind.None;
   end;
 end;
 

--- a/atsynedit/atstrings_undo.pas
+++ b/atsynedit/atstrings_undo.pas
@@ -139,6 +139,19 @@ type
       const AAttribs: TATMarkerAttribArray;
       ACommandCode: integer;
       AUndoOrRedo: TATEditorRunningUndoOrRedo);
+    //2026.09.12 (CudaText perf): bulk version of Add() for the N identical
+    //placeholder undo-items of a block-insert (LineBlockInsertEnds): one
+    //TATEditAction.Insert item per line, same index, empty text, same arrays.
+    //Creates exactly the items N sequential Add() calls would create (same
+    //fields, same order); the tick is sampled every 1024 items - sequential
+    //Add() samples per item, but items of one command differ only when a
+    //pause >= ATStrings_PauseForUndoGroup occurs mid-run, which the periodic
+    //sampling preserves (within 1024 items)
+    procedure AddInsertRun(AIndex: integer; ACount: SizeInt;
+      ACommandCode: integer;
+      const ACarets, ACarets2: TATPointPairArray;
+      const AMarkers, AMarkers2: TATMarkerMarkerArray;
+      const AAttribs: TATMarkerAttribArray);
     procedure AddUnmodifiedMark;
     function DebugText: string;
     function IsEmpty: boolean;
@@ -460,6 +473,105 @@ begin
   //CudaText issue #3084
   while (NGlobalCounter-Items[0].ItemGlobalCounter)>MaxCount do
     Delete(0);
+end;
+
+
+procedure TATUndoList.AddInsertRun(AIndex: integer; ACount: SizeInt;
+  ACommandCode: integer;
+  const ACarets, ACarets2: TATPointPairArray;
+  const AMarkers, AMarkers2: TATMarkerMarkerArray;
+  const AAttribs: TATMarkerAttribArray);
+{
+2026.09.12 (CudaText perf): see the interface comment. Mirrors the statements
+of Add() for the Insert-placeholder case (empty text, NotUndoRedo):
+- command-mark counter: computed once (Add() reads Last.ItemGlobalCounter
+  before each item, but items of this run share the counter, so the value
+  stays the same);
+- FSoftMark/FHardMark: read per item like Add() does; FSoftMark turns false
+  after the first item, exactly like sequential Add() calls;
+- GetTickCount64: sampled per 1024 items (see interface comment);
+- duplicate-change check of Add() never applies (action=Insert);
+- MaxCount trimming: run once at the end (all items share the counter).
+}
+var
+  Item: TATUndoItem;
+  NGlobalCounter: DWord;
+  NCounterFirst, NCounterRest: DWord;
+  NewTick: QWord;
+  i: SizeInt;
+begin
+  if FLocked then Exit;
+  if FMaxCount=0 then Exit;
+  if ACount<=0 then Exit;
+
+  //command-mark counter, mirroring sequential Add() exactly:
+  //- list not empty: all items get Last.Counter (+1 when the mark is set,
+  //  consumed by the first Add);
+  //- list empty: item 1 gets 0 and does NOT consume the mark (Add() reads
+  //  the counter only when bNotEmpty), item 2 consumes it -> items 2..N
+  //  get 1 (0 when no mark)
+  if Count>0 then
+  begin
+    NGlobalCounter:= Last.ItemGlobalCounter;
+    if FNewCommandMark then
+    begin
+      FNewCommandMark:= false;
+      Inc(NGlobalCounter);
+    end;
+    NCounterFirst:= NGlobalCounter;
+    NCounterRest:= NGlobalCounter;
+  end
+  else
+  begin
+    NCounterFirst:= 0;
+    if FNewCommandMark then
+    begin
+      FNewCommandMark:= false;
+      NCounterRest:= 1;
+    end
+    else
+      NCounterRest:= 0;
+  end;
+
+  if Capacity < Count+ACount then
+    Capacity:= Count+ACount;
+
+  NewTick:= GetTickCount64;
+  if (FLastTick>0) and (NewTick-FLastTick>=ATStrings_PauseForUndoGroup) then
+    FSoftMark:= true;
+  FLastTick:= NewTick;
+
+  for i:= 1 to ACount do
+  begin
+    if (i>1) and ((i and 1023)=0) then
+    begin
+      //periodic tick sampling: a long pause inside the loop must set the
+      //soft mark, like per-item Add() would do
+      NewTick:= GetTickCount64;
+      if NewTick-FLastTick>=ATStrings_PauseForUndoGroup then
+      begin
+        FSoftMark:= true;
+        FLastTick:= NewTick;
+      end;
+    end;
+    if i=1 then
+      NGlobalCounter:= NCounterFirst
+    else
+      NGlobalCounter:= NCounterRest;
+    Item:= TATUndoItem.Create(TATEditAction.Insert, AIndex, '', TATLineEnds.None,
+      TATLineState.None, FSoftMark, FHardMark,
+      ACarets, ACarets2, AMarkers, AMarkers2, AAttribs,
+      ACommandCode, NewTick);
+    Item.ItemGlobalCounter:= NGlobalCounter;
+    FList.Add(Item);
+    FSoftMark:= false;
+  end;
+
+  //support MaxCount _actions_ in the list, intead of MaxCount simple items
+  //CudaText issue #3084
+  if Count>0 then
+    while (NGlobalCounter-Items[0].ItemGlobalCounter)>MaxCount do
+      Delete(0);
 end;
 
 

--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -2724,6 +2724,7 @@ var
   NIndentMaximal: integer;
   NLine, NLinesCount, NIndexFrom, NIndexTo: integer;
   i: integer;
+  NHint: SizeInt;
 begin
   //method can be called before 1st paint,
   //so TCanvas.TextWidth (TATSynEdit.UpdateCharSize) will give exception "Control has no parent window"
@@ -2917,15 +2918,34 @@ begin
 
   if not bUseCachedUpdate then
   begin
-    FWrapInfo.Clear;
     FWrapUpdateCache.Clear; //2026.09: cached items are not related to the recalculated WrapInfo anymore
-    FWrapInfo.SetCapacity(NLinesCount);
+    //2026.09.12 (CudaText perf): PrepareRecalc keeps the previous item buffer
+    //(Clear freed it, then AddItems re-allocated it through ~50 ReallocMem
+    //steps copying ~4x of the final data), and pre-sizes it with a good
+    //estimate of the final item count: about (line length div wrap-column)+1
+    //items per line, which is exact for space-less texts (e.g. hex/base64)
+    //and a close lower bound for word-wrapped texts (AddItems still grows
+    //the buffer when the estimate is exceeded)
+    if NWrapColumnNew>0 then
+    begin
+      NHint:= 0;
+      for i:= 0 to NLinesCount-1 do
+        Inc(NHint, CurStrings.LinesLen[i] div NWrapColumnNew + 1);
+    end
+    else
+      //wrap is off (reachable when VirtualMode is not set: doc with folds,
+      //or 1-2 lines): one item per line
+      NHint:= NLinesCount;
+    FWrapInfo.PrepareRecalc(NHint);
     for i:= 0 to NLinesCount-1 do
     begin
       DoCalcWrapInfos(i, NIndentMaximal, FWrapTemps, bConsiderFolding);
       //2026.09.11 (CudaText perf): bulk add of the line's items
       FWrapInfo.AddItems(FWrapTemps);
     end;
+    //2026.09.12: zero the buffer tail, keeping the "items after Count are
+    //zeroed" invariant of the reused buffer
+    FWrapInfo.FinishRecalc;
     FWrapTemps.Clear;
   end
   else

--- a/atsynedit/atsynedit.pas
+++ b/atsynedit/atsynedit.pas
@@ -2723,7 +2723,7 @@ var
   NWrapColumnNew: integer;
   NIndentMaximal: integer;
   NLine, NLinesCount, NIndexFrom, NIndexTo: integer;
-  i, j: integer;
+  i: integer;
 begin
   //method can be called before 1st paint,
   //so TCanvas.TextWidth (TATSynEdit.UpdateCharSize) will give exception "Control has no parent window"
@@ -2763,6 +2763,28 @@ begin
   begin
     ShowOsBarVert:= true;
     UpdateInitialVars(Canvas); //refresh FClientW/H, FRect* for reduced client area
+  end;
+
+  //2026.09.11 fix (word-wrap + gutter autosize):
+  //Same problem as above, but with the "numbers" gutter band: its width is
+  //autosized by Strings.Count (OptNumbersAutosize, e.g. 2 digits for a small
+  //doc -> 7 digits for 1M lines). When the whole text is replaced by the API
+  //(CudaText: ed.set_text_all), this method ran the full wrap calculation
+  //with the STALE layout (FRectMain of the previous small document), then the
+  //first paint called UpdateInitialVars() -> gutter band became wider ->
+  //GetVisibleColumns() changed -> the full wrap recalculation ran a SECOND
+  //time for the whole document. That doubled the set_text_all time for
+  //word-wrapped huge files (CudaText test, 1M lines x 500 chars: set_text_all
+  //~25 sec + first paint ~26 sec, both dominated by the wrap calc).
+  //Fix: when the line count changed since the previous WrapInfo update,
+  //refresh the layout BEFORE reading GetVisibleColumns(), so the calculation
+  //uses the final gutter width; the first paint then sees the same columns
+  //and the "nothing changed" early-exit skips the recalculation.
+  if FOptNumbersAutosize and
+    (FWrapMode<>TATEditorWrapMode.ModeOff) and
+    (Strings.Count<>FWrapInfo.StringsPrevCount) then
+  begin
+    UpdateInitialVars(Canvas); //refresh gutter width, FRect* for the new line count
   end;
 
   FCharSizer.Init(
@@ -2901,8 +2923,8 @@ begin
     for i:= 0 to NLinesCount-1 do
     begin
       DoCalcWrapInfos(i, NIndentMaximal, FWrapTemps, bConsiderFolding);
-      for j:= 0 to FWrapTemps.Count-1 do
-        FWrapInfo.Add(FWrapTemps[j]);
+      //2026.09.11 (CudaText perf): bulk add of the line's items
+      FWrapInfo.AddItems(FWrapTemps);
     end;
     FWrapTemps.Clear;
   end

--- a/atsynedit/atsynedit_fgl.pas
+++ b/atsynedit/atsynedit_fgl.pas
@@ -70,6 +70,8 @@ type
     class Function ItemIsManaged : Boolean; virtual;
     function Add(Item: Pointer): Integer;
     procedure Clear;
+    procedure SetCountFast(NewCount: Integer); //2026.09.12: no zero-fill on growth, caller must fill new slots
+    function ItemPtrRaw(AIndex: integer): Pointer; {$ifdef FGLINLINE} inline; {$endif} //2026.09.12: no bounds check
     procedure Delete(Index: Integer);
     procedure DeleteRange(IndexFrom, IndexTo : Integer);
     procedure InsertRange(AIndex, ACount: Integer);
@@ -502,7 +504,7 @@ begin
   CheckIndex(Index);
   p:=InternalItems[Index];
   if assigned(p) then
-    DeRef(p);	
+    DeRef(p);   
   InternalItems[Index] := Item;
 end;
 
@@ -546,6 +548,40 @@ begin
   else if NewCount < FCount then
     Deref(NewCount, FCount-1);
   FCount := NewCount;
+end;
+
+procedure TFPSList.SetCountFast(NewCount: Integer);
+//2026.09.12 (CudaText perf): SetCount variant without zero-filling the
+//newly added slots: the caller MUST fully overwrite slots [FCount..
+//NewCount-1] right after the call (e.g. TATWrapInfo.AddItems moves all new
+//items there; SetCount zero-filled them first, so every wrap item was
+//written twice: for a 1M-lines word-wrapped document that is ~170Mb of
+//useless memory writes per full WrapInfo recalculation).
+//Shrinking is allowed: managed element types still get Deref, like SetCount.
+begin
+  if (NewCount < 0) or (NewCount > MaxListSize) then
+    Error(SListCountError, NewCount);
+  if NewCount > FCapacity then
+    SetCapacity(NewCount);
+  //2026.09.12: zero-fill the new slots for MANAGED element types: filling
+  //them later via Items[] assignment would deref the garbage left in the
+  //slots; unmanaged types (records, the wrap-items) skip the fill, which
+  //is the point of this method (caller overwrites slots with raw Move)
+  if (NewCount > FCount) and ItemIsManaged then
+    FillByte(InternalItems[FCount]^, (NewCount-FCount) * FItemSize, 0)
+  else if NewCount < FCount then
+    //shrink always Derefs (virtual: frees objects of TFPGObjectList,
+    //releases managed types), exactly like SetCount
+    Deref(NewCount, FCount-1);
+  FCount := NewCount;
+end;
+
+function TFPSList.ItemPtrRaw(AIndex: integer): Pointer;
+//2026.09.12 (CudaText perf): raw item pointer without the bounds check of
+//Get()/_GetItemPtr(): used by TATWrapInfo bulk updates, which write slots
+//at/after Count (count grows right after the writes; single-threaded)
+begin
+  Result := InternalItems[AIndex];
 end;
 
 function TFPSList.Add(Item: Pointer): Integer;

--- a/atsynedit/atsynedit_wrapinfo.pas
+++ b/atsynedit/atsynedit_wrapinfo.pas
@@ -728,6 +728,10 @@ var
   NPartCap, NBufLen: integer;
   bInitialItem: boolean;
   Buf: array[0..cWrapPartBufMax-1] of WideChar;
+  //2026.09.12 (CudaText perf): raw-ASCII fast path state
+  PLineBytes: PByte;
+  NLineBytes: SizeInt;
+  NRest, NIndentLen: integer;
 begin
   //2026.09.12 (CudaText perf): SetCount(0) instead of Clear(): Clear() also
   //does SetCapacity(0), which FREES the item buffer, so the per-line call of
@@ -780,37 +784,77 @@ begin
 
   NPartCap:= Min(NPartCap, cWrapPartBufMax);
 
+  //2026.09.12 (CudaText perf): raw-ASCII fast path - for ASCII-stored lines
+  //(Ex.Wide=false: chars=bytes, all bytes <128) the word-wrap scan works
+  //directly on the line's ANSI buffer (FindWordWrapOffsetBytes), skipping
+  //the per-part byte-to-WideChar conversion (TATStringItem.LineSubBuf,
+  //~0.2s per 1M lines x 500 chars on the reference machine). Wide-stored
+  //lines, proportional fonts and non-printable-ASCII parts (tab/controls)
+  //use the original PWideChar path - results are identical in all cases
+  PLineBytes:= nil;
+  NLineBytes:= 0;
+  if not AFontProportional then
+    AStrings.LineBytesPtr(ALineIndex, PLineBytes, NLineBytes);
+
   NPartOffset:= 1;
   NIndent:= 0;
   bInitialItem:= true;
+  NBufLen:= 0; //filled by the PWideChar path only (indent source check)
 
   repeat
     //2026.09 (CudaText perf): the line part is copied to the stack buffer and
     //scanned by pointer (LineSubBuf + FindWordWrapOffsetBuf): no UnicodeString
     //is allocated per part (was: LineSub + string assign per part, which
     //dominated the wrap calc time of big documents)
-    NBufLen:= AStrings.LineSubBuf(ALineIndex, NPartOffset, NPartCap, @Buf[0]);
-
-    if NBufLen=0 then
+    //2026.09.12: ASCII-stored lines skip the conversion - the raw bytes are
+    //scanned in place; FindWordWrapOffsetBytes returns -1 when the part is
+    //not pure printable ASCII, then the PWideChar path runs for this part
+    NPartLen:= -1;
+    if PLineBytes<>nil then
     begin
-      if not bInitialItem then
+      NRest:= NLineBytes-(NPartOffset-1);
+      if NRest<=0 then
       begin
-        WrapItemPtr:= AItems._GetItemPtr(AItems.Count-1);
-        WrapItemPtr^.NFinal:= TATWrapItemFinal.Final;
+        if not bInitialItem then
+        begin
+          WrapItemPtr:= AItems._GetItemPtr(AItems.Count-1);
+          WrapItemPtr^.NFinal:= TATWrapItemFinal.Final;
+        end;
+        Break;
       end;
-      Break;
+      NPartLen:= ATabHelper.FindWordWrapOffsetBytes(
+        PLineBytes+(NPartOffset-1),
+        Min(NPartCap, NRest),
+        Max(AWrapColumn-NIndent, ATEditorOptions.MinWrapColumnAbs),
+        ANonWordChars,
+        AWrapIndented);
     end;
 
-    NPartLen:= ATabHelper.FindWordWrapOffsetBuf(
-      ALineIndex,
-      //very slow to calc for entire line (eg len=70K),
-      //calc for first NVisColumns chars
-      @Buf[0],
-      NBufLen,
-      Max(AWrapColumn-NIndent, ATEditorOptions.MinWrapColumnAbs),
-      ANonWordChars,
-      AWrapIndented
-      );
+    if NPartLen<0 then
+    begin
+      NBufLen:= AStrings.LineSubBuf(ALineIndex, NPartOffset, NPartCap, @Buf[0]);
+
+      if NBufLen=0 then
+      begin
+        if not bInitialItem then
+        begin
+          WrapItemPtr:= AItems._GetItemPtr(AItems.Count-1);
+          WrapItemPtr^.NFinal:= TATWrapItemFinal.Final;
+        end;
+        Break;
+      end;
+
+      NPartLen:= ATabHelper.FindWordWrapOffsetBuf(
+        ALineIndex,
+        //very slow to calc for entire line (eg len=70K),
+        //calc for first NVisColumns chars
+        @Buf[0],
+        NBufLen,
+        Max(AWrapColumn-NIndent, ATEditorOptions.MinWrapColumnAbs),
+        ANonWordChars,
+        AWrapIndented
+        );
+    end;
 
     WrapItem.Init(ALineIndex, NPartOffset, NPartLen, NIndent, TATWrapItemFinal.Middle, bInitialItem);
     AItems.Add(WrapItem);
@@ -819,7 +863,18 @@ begin
     if AWrapIndented then
       if NPartOffset=1 then
       begin
-        NIndent:= ATabHelper.GetIndentExpandedBuf(ALineIndex, @Buf[0], NBufLen);
+        if NBufLen>0 then
+          NIndent:= ATabHelper.GetIndentExpandedBuf(ALineIndex, @Buf[0], NBufLen)
+        else
+        begin
+          //part 1 used the raw-ASCII path: count leading #32 bytes of the
+          //same char range (GetIndentExpandedBuf's tab branch cannot run:
+          //tab is not accepted by the byte path, so IsCharSpace = #32 only)
+          NIndent:= 0;
+          NIndentLen:= Min(NPartCap, NLineBytes);
+          while (NIndent<NIndentLen) and (PLineBytes[NIndent]=32) do
+            Inc(NIndent);
+        end;
         NIndent:= Min(NIndent, AIndentMaximal);
       end;
 

--- a/atsynedit/atsynedit_wrapinfo.pas
+++ b/atsynedit/atsynedit_wrapinfo.pas
@@ -75,6 +75,12 @@ type
     function IsIndexUniqueForLine(AIndex: integer): boolean;
     property Data[AIndex: integer]: TATWrapItem read GetData; default;
     procedure Add(const AData: TATWrapItem);
+    //2026.09.11 (CudaText perf): bulk add of all items (used by the full
+    //recalculation of WrapInfo): one capacity check + one memory-move per
+    //line, instead of the per-item Add() chain (3 nested calls + virtual
+    //CopyItem per item), which dominated the wrap-items storing for big
+    //wrapped documents; growth policy repeats TFPSList.Expand()
+    procedure AddItems(AItems: TATWrapItems);
     procedure Delete(AIndex: integer);
     procedure Insert(AIndex: integer; const AItem: TATWrapItem);
     procedure FindIndexesOfLineNumber(ALineNum: SizeInt; out AFrom, ATo: integer);
@@ -282,6 +288,42 @@ procedure TATWrapInfo.Add(const AData: TATWrapItem);
 begin
   if FVirtualMode then exit;
   FList.Add(AData);
+end;
+
+procedure TATWrapInfo.AddItems(AItems: TATWrapItems);
+var
+  N, NCount, NCapy: integer;
+begin
+  if FVirtualMode then exit;
+  N:= AItems.Count;
+  if N=0 then exit;
+
+  NCount:= FList.Count;
+  if NCount+N > FList.Capacity then
+  begin
+    //grow like TFPSList.Expand() does (+25% etc), but enough for all N items
+    NCapy:= FList.Capacity;
+    if NCapy>127 then
+      Inc(NCapy, NCapy shr 2)
+    else
+    if NCapy>8 then
+      Inc(NCapy, 16)
+    else
+    if NCapy>3 then
+      Inc(NCapy, 8)
+    else
+      Inc(NCapy, 4);
+    if NCapy < NCount+N then
+      NCapy:= NCount+N;
+    if NCapy>MaxListSize then
+      NCapy:= MaxListSize;
+    FList.Capacity:= NCapy;
+  end;
+
+  //Count grows first (SetCount zero-fills the new slots, keeping the list
+  //invariant "items after Count are zeroed"), then all items are moved at once
+  FList.Count:= NCount+N;
+  System.Move(AItems._GetItemPtr(0)^, FList._GetItemPtr(NCount)^, N*SizeOf(TATWrapItem));
 end;
 
 procedure TATWrapInfo.Delete(AIndex: integer);

--- a/atsynedit/atsynedit_wrapinfo.pas
+++ b/atsynedit/atsynedit_wrapinfo.pas
@@ -81,6 +81,14 @@ type
     //CopyItem per item), which dominated the wrap-items storing for big
     //wrapped documents; growth policy repeats TFPSList.Expand()
     procedure AddItems(AItems: TATWrapItems);
+    //2026.09.12 (CudaText perf): buffer-friendly reset for the full
+    //recalculation: keeps the item buffer when it's big enough for the new
+    //document (Clear() frees it, then the refill re-allocs it through dozens
+    //of ReallocMem growth steps, copying ~4x the final item data)
+    procedure PrepareRecalc(AHintCapacity: SizeInt);
+    //2026.09.12: restores the list invariant "items after Count are zeroed"
+    //(stale items of the previous recalculation may remain in the tail)
+    procedure FinishRecalc;
     procedure Delete(AIndex: integer);
     procedure Insert(AIndex: integer; const AItem: TATWrapItem);
     procedure FindIndexesOfLineNumber(ALineNum: SizeInt; out AFrom, ATo: integer);
@@ -320,10 +328,50 @@ begin
     FList.Capacity:= NCapy;
   end;
 
-  //Count grows first (SetCount zero-fills the new slots, keeping the list
-  //invariant "items after Count are zeroed"), then all items are moved at once
-  FList.Count:= NCount+N;
-  System.Move(AItems._GetItemPtr(0)^, FList._GetItemPtr(NCount)^, N*SizeOf(TATWrapItem));
+  //2026.09.12 (CudaText perf): items are moved BEFORE growing Count, and
+  //Count grows via SetCountFast() without the zero-fill: SetCount()
+  //zero-filled the new slots which are fully overwritten right after, i.e.
+  //every wrap item was written twice (for a 1M-lines word-wrapped document
+  //that is ~170Mb of useless memory writes per full WrapInfo recalculation).
+  //Slots after Count stay zeroed (SetCapacity zero-fills new capacity), so
+  //the list invariant is kept
+  FList.SetCountFast(NCount+N);
+  System.Move(AItems._GetItemPtr(0)^, FList.ItemPtrRaw(NCount)^, N*SizeOf(TATWrapItem));
+end;
+
+procedure TATWrapInfo.PrepareRecalc(AHintCapacity: SizeInt);
+begin
+  if FVirtualMode then exit;
+  if AHintCapacity > MaxListSize then
+    AHintCapacity:= MaxListSize;
+  if AHintCapacity < 0 then
+    AHintCapacity:= 0;
+  //2026.09.12 (CudaText perf): don't free the item buffer here: the old code
+  //called Clear() (which frees the buffer) and the following AddItems() loop
+  //re-allocated it through dozens of ReallocMem growth steps, copying about
+  //4x of the final item data (for 1M word-wrapped lines: ~700Mb of extra
+  //memory copying + page-faulting of fresh pages on Windows). Keeping the
+  //buffer makes the repeated full recalculation (window resize, wrap-mode
+  //toggle) allocation-free. Buffer is trimmed only when the new document
+  //is much smaller (4x) than the buffer, to not hold huge unused memory
+  FList.SetCountFast(0);
+  if FList.Capacity < AHintCapacity then
+    FList.Capacity:= AHintCapacity
+  else
+  if FList.Capacity > AHintCapacity*4 + 1024 then
+    FList.Capacity:= AHintCapacity;
+end;
+
+procedure TATWrapInfo.FinishRecalc;
+var
+  NTail: SizeInt;
+begin
+  if FVirtualMode then exit;
+  //restore the list invariant "items after Count are zeroed": the buffer is
+  //reused, so the tail can contain stale items of the previous recalculation
+  NTail:= FList.Capacity - FList.Count + 1; //+1: the temp slot after Capacity
+  if NTail>0 then
+    FillChar(FList.ItemPtrRaw(FList.Count)^, NTail*SizeOf(TATWrapItem), 0);
 end;
 
 procedure TATWrapInfo.Delete(AIndex: integer);
@@ -681,7 +729,14 @@ var
   bInitialItem: boolean;
   Buf: array[0..cWrapPartBufMax-1] of WideChar;
 begin
-  AItems.Clear;
+  //2026.09.12 (CudaText perf): SetCount(0) instead of Clear(): Clear() also
+  //does SetCapacity(0), which FREES the item buffer, so the per-line call of
+  //ATWrapInfo_CalcLine() from the full WrapInfo recalculation made the temp
+  //list re-allocate its buffer on EVERY document line (1M lines: ~0.5 sec of
+  //pure heap churn). SetCount(0) keeps Capacity; TATWrapItem is an unmanaged
+  //record, so stale bytes after Count cannot harm (Deref is a no-op, and
+  //nothing reads items beyond Count)
+  AItems.SetCountFast(0);
 
   //line folded entirely?
   if AConsiderFolding then


### PR DESCRIPTION

last and  final speed optimizations

improvments:
- hang1 is near 0 in all the commands now
- **set_text_all x6 faster, replace_lines x3, undo x6, redo x2, file_open x3**
- all commands consumes now between 2 to 3s only on the 500mb file
- tests done with cuda_testing_perf plugin
- tests done on a 500mb file with 1M lines
- the commits were oriented to optimize set_text_all and replace_lines but everything improved too when both were optimized

look at the **total** vs **base** numbers, **total** is the new numbers and **base** is the old numbers using the current code

| test | command | cmd | Hang1 | Hang2 | Total | base | status |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| MP1 | replace_lines | 3.2022s | 0.2330s | 0.0230s | 3.4582s | 10.9597s | PASS |
| MP2 | set_text_all | 2.8142s | 0.2280s | 0.0090s | 3.0512s | 17.6520s | PASS |
| MP3 | Delete | 2.1311s | 0.0780s | 0.0060s | 2.2151s | 3.3582s | PASS |
| | Undo | 3.5252s | 0.1090s | 0.0190s | 3.6532s | 17.1329s | |
| | Redo | 2.3551s | 0.0730s | 0.0100s | 2.4381s | 3.1562s | |
| MP4 | Delete | 1.9021s | 0.7400s | 0.0200s | 2.6622s | 4.8083s | PASS |
| | Undo | 2.6972s | 0.0800s | 0.0100s | 2.7872s | 13.2797s | |
| | Redo | 2.3091s | 0.0900s | 0.0100s | 2.4091s | 4.8083s | |
| MP5 | file_open | 2.9102s | 0.0100s | 0.0210s | 2.9412s | 8.9215s | PASS |

# commit 1 - optimize set_text_all hang1

```
   test  wrap lines   command              cmd     Hang1     Hang2     Total      base  status
   ----------------------------------------------------------------------------------------
   MP1   off  1000000 replace_lines    3.0332s   0.3680s   0.0410s   3.4422s         -  PASS  
   MP1   on   1000000 replace_lines    3.0062s   7.4614s   0.0170s  10.4846s  10.9597s  PASS  
   MP2   off  1000000 set_text_all     2.2291s   0.3870s   0.0390s   2.6552s         -  PASS  
   MP2   on   1000000 set_text_all     8.8695s   0.3640s   0.0180s   9.2515s  17.6520s  PASS  
   MP3   off  1000000 Delete           2.0011s   0.0130s   0.0100s   2.0241s         -  PASS  
                      Undo             2.0861s   0.1010s   0.0420s   2.2291s         -        
                      Redo             2.2251s   0.1150s   0.0200s   2.3601s         -        
   MP3   on   1000000 Delete           2.9512s   1.7911s   0.0100s   4.7523s   3.3582s  WARN  
                      Undo             9.6516s   0.3850s   0.0180s  10.0546s  17.1329s        
                      Redo             2.4281s   0.0840s   0.0080s   2.5201s   3.1562s        
        note: Delete hang 1.80s exceeds warn threshold 1.22s
   MP4   off  1000000 Delete           1.8131s   0.1060s   0.0180s   1.9371s         -  PASS  
                      Undo             1.3181s   0.1010s   0.0190s   1.4381s         -        
                      Redo             1.5931s   0.1080s   0.0330s   1.7341s         -        
   MP4   on   1000000 Delete           4.6993s  24.5394s   0.0400s  29.2787s   4.8083s  FAIL  
                      Undo             8.4565s   0.3430s   0.0280s   8.8275s  13.2797s        
                      Redo             4.2082s   0.1090s   0.0350s   4.3522s   4.8083s        
        note: Delete hang 24.58s exceeds FAIL threshold 10.23s; Delete 4.70s exceeds warn threshold 3.71s; Redo 4.21s exceeds warn threshold 3.62s
   MP5   off  1000000 file_open        2.1451s   0.0360s   0.0220s   2.2031s         -  PASS  
   MP5   on   1000000 file_open        8.4495s   0.0510s   0.0170s   8.5175s   8.9215s  PASS 
```
[README.md](https://github.com/user-attachments/files/32136826/README.md)

___________________________________________
# commit 2 - optimize set_text_all self timing

```
   test  wrap lines   command              cmd     Hang1     Hang2     Total      base  status
   ----------------------------------------------------------------------------------------
   MP1   off  1000000 replace_lines    3.1052s   0.4990s   0.0390s   3.6432s         -  PASS  
   MP1   on   1000000 replace_lines    3.1712s   7.4124s   0.0250s  10.6086s  10.9597s  PASS  
   MP2   off  1000000 set_text_all     1.3481s   0.4620s   0.0400s   1.8501s         -  PASS  
   MP2   on   1000000 set_text_all     8.0755s   0.6010s   0.0190s   8.6955s  17.6520s  PASS  
   MP3   off  1000000 Delete           2.0211s   0.0720s   0.0170s   2.1101s         -  PASS  
                      Undo             2.0111s   0.0930s   0.0400s   2.1441s         -        
                      Redo             2.4031s   0.0300s   0.0080s   2.4411s         -        
   MP3   on   1000000 Delete           2.0871s   0.0810s   0.0180s   2.1861s   3.3582s  PASS  
                      Undo             8.5105s   0.5010s   0.0200s   9.0315s  17.1329s        
                      Redo             2.4521s   0.0700s   0.0170s   2.5391s   3.1562s        
   MP4   off  1000000 Delete           1.2981s   0.0750s   0.0410s   1.4141s         -  PASS  
                      Undo             1.2561s   0.0380s   0.0190s   1.3131s         -        
                      Redo             1.3891s   0.0780s   0.0190s   1.4861s         -        
   MP4   on   1000000 Delete           3.9012s   0.0950s   0.0360s   4.0322s   4.8083s  WARN  
                      Undo             7.8084s   0.3030s   0.0270s   8.1385s  13.2797s        
                      Redo             3.8292s   0.1060s   0.0390s   3.9742s   4.8083s        
        note: Delete 3.90s exceeds warn threshold 3.71s; Redo 3.83s exceeds warn threshold 3.62s
   MP5   off  1000000 file_open        1.8921s   0.0240s   0.0180s   1.9341s         -  PASS  
   MP5   on   1000000 file_open        8.1375s   0.0200s   0.0190s   8.1765s   8.9215s  PASS  

```

[README.md](https://github.com/user-attachments/files/32136845/README.md)


________________________________________
# commit3 - optimize replace_lines hang1

```
   test  wrap lines   command              cmd     Hang1     Hang2     Total      base  status
   ----------------------------------------------------------------------------------------
   MP1   off  1000000 replace_lines    2.9652s   0.3060s   0.0230s   3.2942s         -  PASS  
   MP1   on   1000000 replace_lines    3.0072s   2.9332s   0.0190s   5.9593s  10.9597s  PASS  
   MP2   off  1000000 set_text_all     1.3881s   0.5020s   0.0230s   1.9131s         -  PASS  
   MP2   on   1000000 set_text_all     3.6742s   0.3810s   0.0230s   4.0782s  17.6520s  PASS  
   MP3   off  1000000 Delete           2.2051s   0.0760s   0.0060s   2.2871s         -  PASS  
                      Undo             2.0411s   0.1000s   0.0210s   2.1621s         -        
                      Redo             2.4161s   0.0800s   0.0110s   2.5071s         -        
   MP3   on   1000000 Delete           2.0751s   0.0750s   0.0100s   2.1601s   3.3582s  PASS  
                      Undo             4.2732s   0.0630s   0.0090s   4.3452s  17.1329s        
                      Redo             2.4451s   0.0140s   0.0050s   2.4641s   3.1562s        
   MP4   off  1000000 Delete           1.2351s   0.0910s   0.0230s   1.3491s         -  PASS  
                      Undo             1.2601s   0.0970s   0.0270s   1.3841s         -        
                      Redo             1.4901s   0.1010s   0.0240s   1.6151s         -        
   MP4   on   1000000 Delete           2.0211s   0.0390s   0.0100s   2.0701s   4.8083s  PASS  
                      Undo             3.3592s   0.0480s   0.0220s   3.4292s  13.2797s        
                      Redo             2.1161s   0.0730s   0.0220s   2.2111s   4.8083s        
   MP5   off  1000000 file_open        1.8051s   0.0600s   0.0230s   1.8881s         -  PASS  
   MP5   on   1000000 file_open        3.9962s   0.0430s   0.0090s   4.0482s   8.9215s  PASS  
```

[README.md](https://github.com/user-attachments/files/32136852/README.md)

_________________________________________

# commit4 - optimize replace_lines hang1 v2 
with cudatext annex commit - move replace_lines word-wrap update into the API call https://github.com/Alexey-T/CudaText/pull/6459

```
   test  wrap lines   command              cmd     Hang1     Hang2     Total      base  status
   ----------------------------------------------------------------------------------------
   MP1   off  1000000 replace_lines    3.1662s   0.3750s   0.0410s   3.5822s         -  PASS  
   MP1   on   1000000 replace_lines    5.2023s   0.3820s   0.0320s   5.6163s  10.9597s  PASS  
   MP2   off  1000000 set_text_all     1.4831s   0.5450s   0.0340s   2.0621s         -  PASS  
   MP2   on   1000000 set_text_all     3.5932s   0.3100s   0.0370s   3.9402s  17.6520s  PASS  
   MP3   off  1000000 Delete           1.9511s   0.0930s   0.0160s   2.0601s         -  PASS  
                      Undo             2.1131s   0.1050s   0.0360s   2.2541s         -        
                      Redo             2.5471s   0.0780s   0.0170s   2.6422s         -        
   MP3   on   1000000 Delete           3.1182s   0.0900s   0.0160s   3.2242s   3.3582s  PASS  
                      Undo             4.7363s   0.0990s   0.0380s   4.8733s  17.1329s        
                      Redo             2.8022s   0.0830s   0.0110s   2.8962s   3.1562s        
   MP4   off  1000000 Delete           1.8861s   0.0980s   0.0400s   2.0241s         -  PASS  
                      Undo             1.7461s   0.0990s   0.0340s   1.8791s         -        
                      Redo             1.7951s   0.0460s   0.0180s   1.8591s         -        
   MP4   on   1000000 Delete           2.0921s   0.1030s   0.0350s   2.2301s   4.8083s  PASS  
                      Undo             3.4802s   0.0760s   0.0350s   3.5912s  13.2797s        
                      Redo             2.6061s   0.1110s   0.0320s   2.7492s   4.8083s        
   MP5   off  1000000 file_open        1.8941s   0.0110s   0.0180s   1.9231s         -  PASS  
   MP5   on   1000000 file_open        3.8422s   0.0580s   0.0160s   3.9162s   8.9215s  PASS  
```

[README.md](https://github.com/user-attachments/files/32136862/README.md)


______________________________________

# commit 5 - optimize replace_lines self timing

```
   test  wrap lines   command              cmd     Hang1     Hang2     Total      base  status
   ----------------------------------------------------------------------------------------
   MP1   off  1000000 replace_lines    1.7861s   0.2930s   0.0100s   2.0891s         -  PASS  
   MP1   on   1000000 replace_lines    3.2022s   0.2330s   0.0230s   3.4582s  10.9597s  PASS  
   MP2   off  1000000 set_text_all     1.3651s   0.4840s   0.0230s   1.8721s         -  PASS  
   MP2   on   1000000 set_text_all     2.8142s   0.2280s   0.0090s   3.0512s  17.6520s  PASS  
   MP3   off  1000000 Delete           2.2851s   0.5430s   0.0060s   2.8342s         -  PASS  
                      Undo             2.1221s   0.1080s   0.0210s   2.2511s         -        
                      Redo             2.2451s   0.0840s   0.0050s   2.3341s         -        
   MP3   on   1000000 Delete           2.1311s   0.0780s   0.0060s   2.2151s   3.3582s  PASS  
                      Undo             3.5252s   0.1090s   0.0190s   3.6532s  17.1329s        
                      Redo             2.3551s   0.0730s   0.0100s   2.4381s   3.1562s        
   MP4   off  1000000 Delete           1.6761s   0.0680s   0.0100s   1.7541s         -  PASS  
                      Undo             1.2211s   0.1100s   0.0240s   1.3551s         -        
                      Redo             1.4741s   0.1040s   0.0220s   1.6001s         -        
   MP4   on   1000000 Delete           1.9021s   0.7400s   0.0200s   2.6622s   4.8083s  PASS  
                      Undo             2.6972s   0.0800s   0.0100s   2.7872s  13.2797s        
                      Redo             2.3091s   0.0900s   0.0100s   2.4091s   4.8083s        
   MP5   off  1000000 file_open        1.6111s   0.0110s   0.0190s   1.6411s         -  PASS  
   MP5   on   1000000 file_open        2.9102s   0.0100s   0.0210s   2.9412s   8.9215s  PASS  

```


[README.md](https://github.com/user-attachments/files/32136865/README.md)
